### PR TITLE
first pass at adding velocity and acceleration data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,13 +25,27 @@ include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 # sets up include dirs, libraries, and naming convention (no leading "lib")
 # for an OSVR plugin. It also installs the plugin into the right directory.
 # Pass as many source files as you need. See osvrAddPlugin.cmake for full docs.
-osvr_add_plugin(NAME com_osvr_Nolo
-    CPP # indicates we'd like to use the C++ wrapper
-    SOURCES
-    com_osvr_Nolo.cpp
-    "${CMAKE_CURRENT_BINARY_DIR}/com_osvr_Nolo_json.h")
+if (WIN32)
+	osvr_add_plugin(NAME com_osvr_Nolo
+		CPP # indicates we'd like to use the C++ wrapper
+		SOURCES
+		com_osvr_Nolo_win.cpp
+		"${CMAKE_CURRENT_BINARY_DIR}/com_osvr_Nolo_json.h")
+	# If you use other libraries, find them and add a line like:
+	find_path(NOLO_API_INCLUDE nolo_api.h)
+	include_directories("${NOLO_API_INCLUDE}")
+	find_library(NOLO_API_LIBRARY NoLo_USBHID.lib)
+	target_link_libraries(com_osvr_Nolo "${NOLO_API_LIBRARY}")
+else ()
+	osvr_add_plugin(NAME com_osvr_Nolo
+		CPP # indicates we'd like to use the C++ wrapper
+		SOURCES
+		com_osvr_Nolo.cpp
+		"${CMAKE_CURRENT_BINARY_DIR}/com_osvr_Nolo_json.h")
+	# If you use other libraries, find them and add a line like:
+	find_package(HIDAPI REQUIRED)
+	include_directories("${HIDAPI_INCLUDE_DIRS}")
+	target_link_libraries(com_osvr_Nolo "${HIDAPI_LIBRARIES}")
+endif ()
 
-# If you use other libraries, find them and add a line like:
-find_package(HIDAPI REQUIRED)
-include_directories("${HIDAPI_INCLUDE_DIRS}")
-target_link_libraries(com_osvr_Nolo "${HIDAPI_LIBRARIES}")
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,21 +11,21 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" "${LOCAL_CMAKE
 # in the CMake GUI or command line.
 find_package(osvr REQUIRED)
 
-# This generates a header file, from the named json file, containing a string literal
-# named com_osvr_Nolo_json (not null terminated)
-# The file must be added as a source file to some target (as below) to be generated.
-osvr_convert_json(com_osvr_Nolo_json
-    com_osvr_Nolo.json
-    "${CMAKE_CURRENT_BINARY_DIR}/com_osvr_Nolo_json.h")
-
 # Be able to find our generated header file.
 include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 
-# This is just a helper function wrapping CMake's add_library command that
-# sets up include dirs, libraries, and naming convention (no leading "lib")
-# for an OSVR plugin. It also installs the plugin into the right directory.
-# Pass as many source files as you need. See osvrAddPlugin.cmake for full docs.
 if (WIN32)
+	# This generates a header file, from the named json file, containing a string literal
+	# named com_osvr_Nolo_json (not null terminated)
+	# The file must be added as a source file to some target (as below) to be generated.
+	osvr_convert_json(com_osvr_Nolo_json
+    	com_osvr_Nolo_win.json
+    	"${CMAKE_CURRENT_BINARY_DIR}/com_osvr_Nolo_json.h")
+
+	# This is just a helper function wrapping CMake's add_library command that
+	# sets up include dirs, libraries, and naming convention (no leading "lib")
+	# for an OSVR plugin. It also installs the plugin into the right directory.
+	# Pass as many source files as you need. See osvrAddPlugin.cmake for full docs.
 	osvr_add_plugin(NAME com_osvr_Nolo
 		CPP # indicates we'd like to use the C++ wrapper
 		SOURCES
@@ -37,6 +37,11 @@ if (WIN32)
 	find_library(NOLO_API_LIBRARY NoLo_USBHID.lib)
 	target_link_libraries(com_osvr_Nolo "${NOLO_API_LIBRARY}")
 else ()
+
+	osvr_convert_json(com_osvr_Nolo_json
+    	com_osvr_Nolo.json
+    	"${CMAKE_CURRENT_BINARY_DIR}/com_osvr_Nolo_json.h")
+
 	osvr_add_plugin(NAME com_osvr_Nolo
 		CPP # indicates we'd like to use the C++ wrapper
 		SOURCES

--- a/com_osvr_Nolo.cpp
+++ b/com_osvr_Nolo.cpp
@@ -211,7 +211,7 @@ namespace {
 			osvrVec3SetZ(lin_vel, scale *          (data[4] << 8 | data[5]));
 		}
 		void decodeAcceleration(const unsigned char *data,
-			OSVR_LinearVelocityState *lin_accel) {
+			OSVR_LinearAccelerationState *lin_accel) {
 			const double scale = 0.0001;
 			osvrVec3SetX(lin_accel, scale * (int16_t)(data[0] << 8 | data[1]));
 			osvrVec3SetY(lin_accel, scale * (int16_t)(data[2] << 8 | data[3]));

--- a/com_osvr_Nolo.cpp
+++ b/com_osvr_Nolo.cpp
@@ -362,7 +362,7 @@ class NoloDevice {
     OSVR_TrackerDeviceInterface m_tracker;
     OSVR_TimeValue m_lastreport_time;
 	OSVR_Vec3 m_last_home;
-	double m_last_axis[NUM_AXIS];
+	double m_last_axis[2*NUM_AXIS];
 };
 
 class HardwareDetection {

--- a/com_osvr_Nolo.cpp
+++ b/com_osvr_Nolo.cpp
@@ -42,363 +42,454 @@ Yann Vernier
 // Anonymous namespace to avoid symbol collision
 namespace {
 
-  // btea_decrypt function
-  #include "btea.c"
+	// btea_decrypt function
+#include "btea.c"
 
-  #if 0
-  void hexdump(unsigned char *data, int len) {
-    char fill = std::cout.fill();
-    std::streamsize w = std::cout.width();
-    std::ios_base::fmtflags f = std::cout.flags();
-    for (int i=0; i<len; i++) {
-      std::cout << std::setw(2) << std::setfill('0')
-		<< std::hex << (int)data[i];
-      if (i%8==7)
-	std::cout << " ";
-    }
-    std::cout << std::endl;
-    std::cout.fill(fill);
-    std::cout.width(w);
-    std::cout.flags(f);
-  };
-  #endif
-  
-const static int NUM_AXIS    = 4;
-const static int NUM_BUTTONS = 6;
-class NoloDevice {
-  public:
-    NoloDevice(OSVR_PluginRegContext ctx,
-	       char *path) {
-        /// Create the initialization options
-        OSVR_DeviceInitOptions opts = osvrDeviceCreateInitOptions(ctx);
+#if 0
+	void hexdump(unsigned char *data, int len) {
+		char fill = std::cout.fill();
+		std::streamsize w = std::cout.width();
+		std::ios_base::fmtflags f = std::cout.flags();
+		for (int i=0; i<len; i++) {
+			std::cout << std::setw(2) << std::setfill('0')
+				<< std::hex << (int)data[i];
+			if (i%8==7)
+				std::cout << " ";
+		}
+		std::cout << std::endl;
+		std::cout.fill(fill);
+		std::cout.width(w);
+		std::cout.flags(f);
+	};
+#endif
 
-	std::cout << "Nolo: opening " << path <<
-	  " for " << this << std::endl;
-	m_hid = hid_open_path(path);
+	const static int NUM_AXIS = 4;
+	const static int NUM_BUTTONS = 6;
+	class NoloDevice {
+	public:
+		NoloDevice(OSVR_PluginRegContext ctx,
+			char *path) {
+			/// Create the initialization options
+			OSVR_DeviceInitOptions opts = osvrDeviceCreateInitOptions(ctx);
 
-        /// Indicate that we'll want 7 analog channels.
-        //osvrDeviceAnalogConfigure(opts, &m_analog, 2*3+1);
-	// update this to 9 analog channels to include the trigger
-        osvrDeviceAnalogConfigure(opts, &m_analog, NUM_AXIS*2+1);
-	/// And 6 buttons per controller
-        osvrDeviceButtonConfigure(opts, &m_button, 2*NUM_BUTTONS);
-	/// And tracker capability
-        osvrDeviceTrackerConfigure(opts, &m_tracker);
+			std::cout << "Nolo: opening " << path <<
+				" for " << this << std::endl;
+			m_hid = hid_open_path(path);
 
-        /// Create the device token with the options
-        m_dev.initAsync(ctx, "LYRobotix Nolo", opts);
+			/// Indicate that we'll want 7 analog channels.
+			//osvrDeviceAnalogConfigure(opts, &m_analog, 2*3+1);
+			// update this to 9 analog channels to include the trigger
+			osvrDeviceAnalogConfigure(opts, &m_analog, NUM_AXIS * 2 + 1);
+			/// And 6 buttons per controller
+			osvrDeviceButtonConfigure(opts, &m_button, 2 * NUM_BUTTONS);
+			/// And tracker capability
+			osvrDeviceTrackerConfigure(opts, &m_tracker);
 
-        /// Send JSON descriptor
-        m_dev.sendJsonDescriptor(com_osvr_Nolo_json);
+			/// Create the device token with the options
+			m_dev.initAsync(ctx, "LYRobotix Nolo", opts);
 
-        /// Register update callback
-        m_dev.registerUpdateCallback(this);
+			/// Send JSON descriptor
+			m_dev.sendJsonDescriptor(com_osvr_Nolo_json);
 
-	memset(&oldreports[0][0], 0, sizeof oldreports);
-    }
-    ~NoloDevice() {
-      std::cout << "Nolo: deleting " << this << std::endl;
-      hid_close(m_hid);
-    }
-  
-    OSVR_ReturnCode update() {
-      unsigned char buf[64];
-      const int cryptwords = (64-4)/4, cryptoffset=1;
-      static const uint32_t key[4] =
-	{0x875bcc51, 0xa7637a66, 0x50960967, 0xf8536c51};
-      uint32_t cryptpart[cryptwords];
-      int i;
+			/// Register update callback
+			m_dev.registerUpdateCallback(this);
 
-      // TODO: timestamp frame received?
-      if (!m_hid)
-	 OSVR_RETURN_FAILURE;
-      //std::cout << "Reading HID data from " << m_hid << std::endl;
-      if(hid_read(m_hid, buf, sizeof buf) != sizeof buf)
-	return OSVR_RETURN_FAILURE;
-      osvrTimeValueGetNow(&m_lastreport_time);
+			memset(&oldreports[0][0], 0, sizeof oldreports);
+		}
+		~NoloDevice() {
+			std::cout << "Nolo: deleting " << this << std::endl;
+			hid_close(m_hid);
+		}
 
-      // Check for duplicate reports before decrypting
-      switch (buf[0]) {
-	case 0xa5:
-	case 0xa6:
-	  if (memcmp(oldreports[buf[0]-0xa5], buf, sizeof buf))
-	    memcpy(oldreports[buf[0]-0xa5], buf, sizeof buf);
-	  else
-	    return OSVR_RETURN_SUCCESS;	// Duplicate report
-	  break;
-	default:
-	  return OSVR_RETURN_SUCCESS; // Unknown report
-      }
-      //std::cout << "R ";
-      //hexdump(buf, sizeof buf);
-      // Decrypt encrypted portion
-      for (i=0; i<cryptwords; i++) {
-	cryptpart[i] =
-	  ((uint32_t)buf[cryptoffset+4*i  ])<<0  |
-	  ((uint32_t)buf[cryptoffset+4*i+1])<<8  |
-	  ((uint32_t)buf[cryptoffset+4*i+2])<<16 |
-	  ((uint32_t)buf[cryptoffset+4*i+3])<<24;
-      }
-      btea_decrypt(cryptpart, cryptwords, 1, key);
-      for (i=0; i<cryptwords; i++) {
-	buf[cryptoffset+4*i  ] = cryptpart[i]>>0;
-	buf[cryptoffset+4*i+1] = cryptpart[i]>>8;
-	buf[cryptoffset+4*i+2] = cryptpart[i]>>16;
-	buf[cryptoffset+4*i+3] = cryptpart[i]>>24;
-      }
-      //std::cout << "D ";
-      //hexdump(buf, sizeof buf);
-      
-      switch (buf[0]) {
-      case 0xa5:  // controllers frame
-	decodeControllerCV1(0, buf+1);
-	decodeControllerCV1(1, buf+64-controllerLength);
-	break;
-      case 0xa6:
-	decodeHeadsetMarkerCV1(buf+0x15);
-	decodeBaseStationCV1(buf+0x36);
-	break;
-      }
-      return OSVR_RETURN_SUCCESS;
-    }
+		OSVR_ReturnCode update() {
+			unsigned char buf[64];
+			const int cryptwords = (64 - 4) / 4, cryptoffset = 1;
+			static const uint32_t key[4] =
+			{ 0x875bcc51, 0xa7637a66, 0x50960967, 0xf8536c51 };
+			uint32_t cryptpart[cryptwords];
+			int i;
 
-    // Sets vibration strength in percent
-    int setVibration(unsigned char left,
-		     unsigned char right) {
-      unsigned char data[4] = {0xaa, 0x66, left, right};
-      return hid_write(m_hid, data, sizeof data);
-    }
-  
-  private:
-    unsigned char oldreports[2][64];
-    void decodePosition(const unsigned char *data,
+			// TODO: timestamp frame received?
+			if (!m_hid)
+				OSVR_RETURN_FAILURE;
+			//std::cout << "Reading HID data from " << m_hid << std::endl;
+			if (hid_read(m_hid, buf, sizeof buf) != sizeof buf)
+				return OSVR_RETURN_FAILURE;
+			osvrTimeValueGetNow(&m_lastreport_time);
+
+			// Check for duplicate reports before decrypting
+			switch (buf[0]) {
+			case 0xa5:
+			case 0xa6:
+				if (memcmp(oldreports[buf[0] - 0xa5], buf, sizeof buf))
+					memcpy(oldreports[buf[0] - 0xa5], buf, sizeof buf);
+				else
+					return OSVR_RETURN_SUCCESS;	// Duplicate report
+				break;
+			default:
+				return OSVR_RETURN_SUCCESS; // Unknown report
+			}
+			//std::cout << "R ";
+			//hexdump(buf, sizeof buf);
+			// Decrypt encrypted portion
+			for (i = 0; i < cryptwords; i++) {
+				cryptpart[i] =
+					((uint32_t)buf[cryptoffset + 4 * i]) << 0 |
+					((uint32_t)buf[cryptoffset + 4 * i + 1]) << 8 |
+					((uint32_t)buf[cryptoffset + 4 * i + 2]) << 16 |
+					((uint32_t)buf[cryptoffset + 4 * i + 3]) << 24;
+			}
+			btea_decrypt(cryptpart, cryptwords, 1, key);
+			for (i = 0; i < cryptwords; i++) {
+				buf[cryptoffset + 4 * i] = cryptpart[i] >> 0;
+				buf[cryptoffset + 4 * i + 1] = cryptpart[i] >> 8;
+				buf[cryptoffset + 4 * i + 2] = cryptpart[i] >> 16;
+				buf[cryptoffset + 4 * i + 3] = cryptpart[i] >> 24;
+			}
+			//std::cout << "D ";
+			//hexdump(buf, sizeof buf);
+
+			switch (buf[0]) {
+			case 0xa5:  // controllers frame
+				decodeControllerCV1(0, buf + 1);
+				decodeControllerCV1(1, buf + 64 - controllerLength);
+				break;
+			case 0xa6:
+				decodeHeadsetMarkerCV1(buf + 0x15);
+				decodeBaseStationCV1(buf + 0x36);
+				break;
+			}
+			return OSVR_RETURN_SUCCESS;
+		}
+
+		// Sets vibration strength in percent
+		int setVibration(unsigned char left,
+			unsigned char right) {
+			unsigned char data[4] = { 0xaa, 0x66, left, right };
+			return hid_write(m_hid, data, sizeof data);
+		}
+
+	private:
+		unsigned char oldreports[2][64];
+		void decodePosition(const unsigned char *data,
 			OSVR_PositionState *pos) {
-      const double scale = 0.0001;
-      osvrVec3SetX(pos, scale * (int16_t)(data[0]<<8 | data[1]));
-      osvrVec3SetY(pos, scale * (int16_t)(data[2]<<8 | data[3]));
-      osvrVec3SetZ(pos, scale *          (data[4]<<8 | data[5]));
-    }
-    void decodeOrientation(const unsigned char *data,
-			   OSVR_OrientationState *quat) {
-      double w,i,j,k, scale;
-      // CV1 order
-      w = (int16_t)(data[0]<<8 | data[1]);
-      i = (int16_t)(data[2]<<8 | data[3]);
-      j = (int16_t)(data[4]<<8 | data[5]);
-      k = (int16_t)(data[6]<<8 | data[7]);
-      // Normalize (unknown if scale is constant)
-      //scale = 1.0/sqrt(i*i+j*j+k*k+w*w);
-      // Turns out it is fixed point. But the android driver author
-      // either didn't know, or didn't trust it.
-      // Unknown if normalizing it helps OSVR!
-      scale = 1.0 / 16384;
-      //std::cout << "Scale: " << scale << std::endl;
-      w *= scale;
-      i *= scale;
-      j *= scale;
-      k *= scale;
-      // Reorder
-      osvrQuatSetW(quat, w);
-      osvrQuatSetX(quat, i);
-      osvrQuatSetY(quat, k);
-      osvrQuatSetZ(quat, -j);
-    }
-    void decodeControllerCV1(int idx, unsigned char *data) {
-      enum ControllerOffsets {
-	    hwversion   = 0,	// guessed!
-	    fwversion   = 1,
-	    position    = 3,
-	    orientation = 3+3*2,
-	    ofsbuttons  = 3+3*2+4*2,
-	    touchid     = 3+3*2+4*2+1,
-	    touchx      = 3+3*2+4*2+2,
-	    touchy      = 3+3*2+4*2+3,
-	    battery     = 3+3*2+4*2+4,
-      };
-      OSVR_PoseState pose;
-      uint8_t buttons, bit;
-      int trigger_pressed = 0;
-
-      if (data[hwversion] != 2 || data[fwversion] != 1) {
-	// Unknown version
-	/* Happens when controllers aren't on. 
-	std::cout << "Nolo: Unknown controller " << idx
-		  << " version " << (int)data[0] << " " << (int)data[1]
-		  << std::endl;
-	*/
-	return;
-      }
-
-      decodePosition(data+position, &pose.translation);
-      decodeOrientation(data+orientation, &pose.rotation);
-
-      osvrDeviceTrackerSendPoseTimestamped(m_dev, m_tracker, &pose, 2+idx, &m_lastreport_time);
-      
-      buttons = data[ofsbuttons];
-      // TODO: report buttons for both controllers in one call?
-      for (bit=0; bit<NUM_BUTTONS; bit++){
-	osvrDeviceButtonSetValueTimestamped(m_dev, m_button,
-				 (buttons & 1<<bit ? OSVR_BUTTON_PRESSED
-				  : OSVR_BUTTON_NOT_PRESSED), idx*6+bit,
-				 &m_lastreport_time);
-	if(bit == 1){
-	    if(buttons & 1<<bit){
-		trigger_pressed = 1;
-	    }else{
-		trigger_pressed = 0;
-	    }
-	}
-      }
-      // next byte is touch ID bitmask (identical to buttons bit 5)
-
-      // Touch X and Y coordinates
-      // //assumes 0 to 255
-      // normalize from -1 to 1
-      // z = 2*[x - min / (max - min) - 1]
-      // z = 2*(x - 0 / (255 - 0) - 1]
-      // z = 2*(x/255) -1
-      // normalize 0 to 1
-      // x/255
-      double axis_value;
-      if (data[touchid]) {  // Only report touch if there is one
-        axis_value = 2*data[touchx]/255.0 - 1;
-		// Attempt to calibrate, assuming trackpads are only good out to about 60%
-		axis_value *= 1.6667;
-		axis_value = std::fmax(-1, std::fmin(axis_value, 1));
-        // invert axis
-        axis_value *= -1;
-		// Fix edge case by guessing appropriate value (necessary because touchid apparently doesn't always work)
-		if (data[touchx] == 0) { 
-			axis_value = m_last_axis[idx*NUM_AXIS + 0] < 0 ? -1 : 1;
+			const double scale = 0.0001;
+			osvrVec3SetX(pos, scale * (int16_t)(data[0] << 8 | data[1]));
+			osvrVec3SetY(pos, scale * (int16_t)(data[2] << 8 | data[3]));
+			osvrVec3SetZ(pos, scale *          (data[4] << 8 | data[5]));
 		}
-		m_last_axis[idx*NUM_AXIS + 0] = axis_value;
-        osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, axis_value,   idx*NUM_AXIS+0, &m_lastreport_time);
-
-        axis_value = 2*((int)data[touchy])/255.0 -1;
-		// Attempt to calibrate, assuming trackpads are only good out to about 60%
-		axis_value *= 1.6667;
-		axis_value = std::fmax(-1, std::fmin(axis_value, 1));
-		// invert axis
-        axis_value *= -1;
-		// Fix edge case by guessing appropriate value (necessary because touchid apparently doesn't always work)
-		if (data[touchy] == 0) {
-			axis_value = m_last_axis[idx*NUM_AXIS + 1] < 0 ? -1 : 1;
+		void decodeOrientation(const unsigned char *data,
+			OSVR_OrientationState *quat) {
+			double w, i, j, k, scale;
+			// CV1 order
+			w = (int16_t)(data[0] << 8 | data[1]);
+			i = (int16_t)(data[2] << 8 | data[3]);
+			j = (int16_t)(data[4] << 8 | data[5]);
+			k = (int16_t)(data[6] << 8 | data[7]);
+			// Normalize (unknown if scale is constant)
+			//scale = 1.0/sqrt(i*i+j*j+k*k+w*w);
+			// Turns out it is fixed point. But the android driver author
+			// either didn't know, or didn't trust it.
+			// Unknown if normalizing it helps OSVR!
+			scale = 1.0 / 16384;
+			//std::cout << "Scale: " << scale << std::endl;
+			w *= scale;
+			i *= scale;
+			j *= scale;
+			k *= scale;
+			// Reorder
+			osvrQuatSetW(quat, w);
+			osvrQuatSetX(quat, i);
+			osvrQuatSetY(quat, k);
+			osvrQuatSetZ(quat, -j);
 		}
-		m_last_axis[idx*NUM_AXIS + 1] = axis_value;
-        osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, axis_value, idx*NUM_AXIS+1, &m_lastreport_time);
-	  }
-	  else { // Otherwise, report a centered value
-		  axis_value = 0;
-		  osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, axis_value, idx*NUM_AXIS + 0, &m_lastreport_time);
-		  osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, axis_value, idx*NUM_AXIS + 1, &m_lastreport_time);
-	  }
-      // trigger (emulated analog axis)
-      osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, trigger_pressed, idx*NUM_AXIS+2, &m_lastreport_time);
-      // battery level
-      axis_value = data[battery]/255.0; 
-      osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, axis_value, idx*NUM_AXIS+3, &m_lastreport_time);
-    }
-    void decodeHeadsetMarkerCV1(unsigned char *data) {
-      enum MarkerOffsets {
-	    hwversion    = 0,	// guessed!
-	    fwversion    = 1,
-	    position     = 3,
-	    homeposition = 3+3*2,
-	    orientation  = 3+2*3*2+1,
-      };
-      if (data[hwversion] != 2 || data[fwversion] != 1) {
-	/* Happens with corrupt packages (mixed with controller data)
-	std::cout << "Nolo: Unknown headset marker"
-		  << " version " << (int)data[0] << " " << (int)data[1]
-		  << std::endl;
-	*/
-	// Unknown version
-	return;
-      }
+		void decodeVelocity(const unsigned char *data,
+			OSVR_LinearVelocityState *lin_vel) {
+			const double scale = 0.0001;
+			osvrVec3SetX(lin_vel, scale * (int16_t)(data[0] << 8 | data[1]));
+			osvrVec3SetY(lin_vel, scale * (int16_t)(data[2] << 8 | data[3]));
+			osvrVec3SetZ(lin_vel, scale *          (data[4] << 8 | data[5]));
+		}
+		void decodeAcceleration(const unsigned char *data,
+			OSVR_LinearVelocityState *lin_accel) {
+			const double scale = 0.0001;
+			osvrVec3SetX(lin_accel, scale * (int16_t)(data[0] << 8 | data[1]));
+			osvrVec3SetY(lin_accel, scale * (int16_t)(data[2] << 8 | data[3]));
+			osvrVec3SetZ(lin_accel, scale *          (data[4] << 8 | data[5]));
+		}
+		void decodeAngularVelocity(const unsigned char *data,
+			OSVR_AngularVelocityState *ang_vel) {
+			double i, j, k; 
+			i = (int16_t)(data[0] << 8 | data[1]);
+			j = (int16_t)(data[2] << 8 | data[3]);
+			k = (int16_t)(data[4] << 8 | data[5]);
+			osvrQuatSetX(&ang_vel->incrementalRotation, i);
+			osvrQuatSetY(&ang_vel->incrementalRotation, k);
+			osvrQuatSetZ(&ang_vel->incrementalRotation, -j);
+			// magnitude is rotation in rad/s
+			osvrQuatSetW(&ang_vel->incrementalRotation, sqrt(i*i + j*j + k*k));
+			ang_vel->dt = 1.0; 
+		}
+		void decodeAngularAcceleration(const unsigned char *data,
+			OSVR_AngularAccelerationState *ang_accel) {
+			double i, j, k;
+			i = (int16_t)(data[0] << 8 | data[1]);
+			j = (int16_t)(data[2] << 8 | data[3]);
+			k = (int16_t)(data[4] << 8 | data[5]);
+			osvrQuatSetX(&ang_accel->incrementalRotation, i);
+			osvrQuatSetY(&ang_accel->incrementalRotation, k);
+			osvrQuatSetZ(&ang_accel->incrementalRotation, -j);
+			// magnitude is rotation in rad/s*2
+			osvrQuatSetW(&ang_accel->incrementalRotation, sqrt(i*i + j*j + k*k));
+			ang_accel->dt = 1.0;
+		}
 
-      OSVR_PositionState home;
-      OSVR_PoseState hmd;
-      
-      decodePosition(data+position, &hmd.translation);
-      decodePosition(data+homeposition, &home);
-      decodeOrientation(data+orientation, &hmd.rotation);
+		void decodeControllerCV1(int idx, unsigned char *data) {
+			enum ControllerOffsets {
+				hwversion = 0,	// guessed!
+				fwversion = 1,
+				position = 3,
+				orientation = 3 + 3 * 2,
+				ofsbuttons = 3 + 3 * 2 + 4 * 2,
+				touchid = 3 + 3 * 2 + 4 * 2 + 1,
+				touchx = 3 + 3 * 2 + 4 * 2 + 2,
+				touchy = 3 + 3 * 2 + 4 * 2 + 3,
+				battery = 3 + 3 * 2 + 4 * 2 + 4,
+				velocity = 3 + 3 * 2 + 4 * 2 + 5,  // Added with 2.0/2.1 firmware
+				accel = 3 + 3 * 2 + 4 * 2 + 5 + 3 * 2,
+				ang_velocity = 3 + 3 * 2 + 4 * 2 + 5 + 6 * 2,
+				ang_accel = 3 + 3 * 2 + 4 * 2 + 5 + 9 * 2,
+				state = 3 + 3 * 2 + 4 * 2 + 5 + 12 * 2
+			};
+			OSVR_PoseState pose;
+			uint8_t buttons, bit;
+			int trigger_pressed = 0;
 
-	  // Send button press if home position changed
-	  if (home.data[0] != m_last_home.data[0]) { // An exact comparison on the x value is probably sufficient, if not necessarily proper
-		  osvrDeviceButtonSetValueTimestamped(m_dev, m_button, OSVR_BUTTON_PRESSED, 12, &m_lastreport_time);
-		  m_last_home.data[0] = home.data[0];
-	  }
-	  else {
-		  osvrDeviceButtonSetValueTimestamped(m_dev, m_button, OSVR_BUTTON_NOT_PRESSED, 12, &m_lastreport_time);
-	  }
+			if (data[hwversion] != 2 || data[fwversion] != 1) {
+				// Unknown version
+				/* Happens when controllers aren't on.
+				std::cout << "Nolo: Unknown controller " << idx
+				<< " version " << (int)data[0] << " " << (int)data[1]
+				<< std::endl;
+				*/
+				return;
+			}
 
-      // Tracker viewer kept using the home for head.
-      // Something wrong with how they handle the descriptors. 
-      osvrDeviceTrackerSendPositionTimestamped(m_dev, m_tracker, &home, 0,
-		      &m_lastreport_time);
+			decodePosition(data + position, &pose.translation);
+			decodeOrientation(data + orientation, &pose.rotation);
 
-      osvrDeviceTrackerSendPoseTimestamped(m_dev, m_tracker, &hmd, 1,
-		      &m_lastreport_time);
-    }
-    void decodeBaseStationCV1(unsigned char *data) {
-      enum MarkerOffsets {
-	    hwversion = 0,	// guessed!
-	    fwversion = 1,
-	    battery   = 2
-      };
-      if (data[hwversion] != 2 || data[fwversion] != 1)
-	// Unknown version
-	return;
+			osvrDeviceTrackerSendPoseTimestamped(m_dev, m_tracker, &pose, 2 + idx, &m_lastreport_time);
 
-      osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, data[battery], 2*NUM_AXIS,
-		      &m_lastreport_time);
-    }
-  
-    static const int controllerLength = 3 + (3+4)*2 + 2 + 2 + 1;
-    osvr::pluginkit::DeviceToken m_dev;
-    hid_device* m_hid;
-    OSVR_AnalogDeviceInterface m_analog;
-    OSVR_ButtonDeviceInterface m_button;
-    OSVR_TrackerDeviceInterface m_tracker;
-    OSVR_TimeValue m_lastreport_time;
-	OSVR_Vec3 m_last_home;
-	double m_last_axis[NUM_AXIS];
-};
+			buttons = data[ofsbuttons];
+			// TODO: report buttons for both controllers in one call?
+			for (bit = 0; bit < NUM_BUTTONS; bit++){
+				osvrDeviceButtonSetValueTimestamped(m_dev, m_button,
+					(buttons & 1 << bit ? OSVR_BUTTON_PRESSED
+					: OSVR_BUTTON_NOT_PRESSED), idx * 6 + bit,
+					&m_lastreport_time);
+				if (bit == 1){
+					if (buttons & 1 << bit){
+						trigger_pressed = 1;
+					}
+					else{
+						trigger_pressed = 0;
+					}
+				}
+			}
+			// next byte is touch ID bitmask (identical to buttons bit 5)
 
-class HardwareDetection {
-  public:
-    HardwareDetection() : m_found(false) {}
-    OSVR_ReturnCode operator()(OSVR_PluginRegContext ctx) {
+			// Touch X and Y coordinates
+			// //assumes 0 to 255
+			// normalize from -1 to 1
+			// z = 2*[x - min / (max - min) - 1]
+			// z = 2*(x - 0 / (255 - 0) - 1]
+			// z = 2*(x/255) -1
+			// normalize 0 to 1
+			// x/255
+			double axis_value;
+			if (data[touchid]) {  // Only report touch if there is one
+				axis_value = 2 * data[touchx] / 255.0 - 1;
+				// Attempt to calibrate, assuming trackpads are only good out to about 60%
+				axis_value *= 1.6667;
+				axis_value = std::fmax(-1, std::fmin(axis_value, 1));
+				// invert axis
+				axis_value *= -1;
+				// Fix edge case by guessing appropriate value (necessary because touchid apparently doesn't always work)
+				if (data[touchx] == 0) {
+					axis_value = m_last_axis[idx*NUM_AXIS + 0] < 0 ? -1 : 1;
+				}
+				m_last_axis[idx*NUM_AXIS + 0] = axis_value;
+				osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, axis_value, idx*NUM_AXIS + 0, &m_lastreport_time);
 
-      // TODO: probe for new devices only
-      if (m_found)
-	return OSVR_RETURN_SUCCESS;
+				axis_value = 2 * ((int)data[touchy]) / 255.0 - 1;
+				// Attempt to calibrate, assuming trackpads are only good out to about 60%
+				axis_value *= 1.6667;
+				axis_value = std::fmax(-1, std::fmin(axis_value, 1));
+				// invert axis
+				axis_value *= -1;
+				// Fix edge case by guessing appropriate value (necessary because touchid apparently doesn't always work)
+				if (data[touchy] == 0) {
+					axis_value = m_last_axis[idx*NUM_AXIS + 1] < 0 ? -1 : 1;
+				}
+				m_last_axis[idx*NUM_AXIS + 1] = axis_value;
+				osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, axis_value, idx*NUM_AXIS + 1, &m_lastreport_time);
+			}
+			else { // Otherwise, report a centered value
+				axis_value = 0;
+				osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, axis_value, idx*NUM_AXIS + 0, &m_lastreport_time);
+				osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, axis_value, idx*NUM_AXIS + 1, &m_lastreport_time);
+			}
+			// trigger (emulated analog axis)
+			osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, trigger_pressed, idx*NUM_AXIS + 2, &m_lastreport_time);
+			// battery level
+			axis_value = data[battery] / 255.0;
+			osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, axis_value, idx*NUM_AXIS + 3, &m_lastreport_time);
 
-      struct hid_device_info *hid_devices, *cur_dev;
-      hid_devices = hid_enumerate(0x0483, 0x5750);
-      if (!hid_devices)
-	return OSVR_RETURN_FAILURE;
+			// velocity and acceleration data
+			OSVR_LinearVelocityState lin_vel_state;
+			OSVR_LinearAccelerationState lin_accel_state; 
+			decodeVelocity(data + velocity, &lin_vel_state);
+			decodeAcceleration(data + accel, &lin_accel_state);
 
-      for (cur_dev = hid_devices; cur_dev; cur_dev = cur_dev->next) {
-	if (wcscmp(cur_dev->manufacturer_string, L"LYRobotix")==0 &&
-	    wcscmp(cur_dev->product_string, L"NOLO")==0) {
-	  /// TODO: Distinguish Headset Marker from other parts?
-	  /// Create our device object
-	  osvr::pluginkit::registerObjectForDeletion
-	    (ctx, new NoloDevice(ctx, cur_dev->path));
-	  m_found = true;
-	}
-      }
-      
-      hid_free_enumeration(hid_devices);
-      return OSVR_RETURN_SUCCESS;
-    }
+			osvrDeviceTrackerSendLinearVelocityTimestamped(m_dev, m_tracker, &lin_vel_state, 2 + idx, &m_lastreport_time);
+			osvrDeviceTrackerSendLinearAccelerationTimestamped(m_dev, m_tracker, &lin_accel_state, 2 + idx, &m_lastreport_time);
 
-  private:
-    /// @brief Have we found our device yet? (this limits the plugin to one
-    /// instance)
-    bool m_found;
-};
+			OSVR_AngularVelocityState ang_vel_state; 
+			OSVR_AngularAccelerationState ang_accel_state; 
+			decodeAngularVelocity(data + ang_velocity, &ang_vel_state);
+			decodeAngularAcceleration(data + ang_accel, &ang_accel_state);
+
+			osvrDeviceTrackerSendAngularVelocityTimestamped(m_dev, m_tracker, &ang_vel_state, 2 + idx, &m_lastreport_time);
+			osvrDeviceTrackerSendAngularAccelerationTimestamped(m_dev, m_tracker, &ang_accel_state, 2 + idx, &m_lastreport_time);
+
+		    // should we be using the "state" information for anything? 
+
+		}
+		void decodeHeadsetMarkerCV1(unsigned char *data) {
+			enum MarkerOffsets {
+				hwversion = 0,	// guessed!
+				fwversion = 1,
+				position = 3,
+				homeposition = 3 + 3 * 2,
+				orientation = 3 + 2 * 3 * 2 + 1,       // why the +1 offset here? (firmware dependent?)
+				velocity = 3 + 2 * 3 * 2 + 1 + 4 * 2,  // Added with 2.0/2.1 firmware
+				accel = 3 + 2 * 3 * 2 + 1 + 7 * 2,
+				ang_velocity = 3 + 2 * 3 * 2 + 1 + 10 * 2,
+				ang_accel = 3 + 2 * 3 * 2 + 1 + 13 * 2,
+				state = 3 + 2 * 3 * 2 + 1 + 16 * 2
+			};
+			if (data[hwversion] != 2 || data[fwversion] != 1) {
+				/* Happens with corrupt packages (mixed with controller data)
+				std::cout << "Nolo: Unknown headset marker"
+				<< " version " << (int)data[0] << " " << (int)data[1]
+				<< std::endl;
+				*/
+				// Unknown version
+				return;
+			}
+
+			OSVR_PositionState home;
+			OSVR_PoseState hmd;
+
+			decodePosition(data + position, &hmd.translation);
+			decodePosition(data + homeposition, &home);
+			decodeOrientation(data + orientation, &hmd.rotation);
+
+			// Send button press if home position changed
+			if (home.data[0] != m_last_home.data[0]) { // An exact comparison on the x value is probably sufficient, if not necessarily proper
+				osvrDeviceButtonSetValueTimestamped(m_dev, m_button, OSVR_BUTTON_PRESSED, 12, &m_lastreport_time);
+				m_last_home.data[0] = home.data[0];
+			}
+			else {
+				osvrDeviceButtonSetValueTimestamped(m_dev, m_button, OSVR_BUTTON_NOT_PRESSED, 12, &m_lastreport_time);
+			}
+
+			// Tracker viewer kept using the home for head.
+			// Something wrong with how they handle the descriptors. 
+			osvrDeviceTrackerSendPositionTimestamped(m_dev, m_tracker, &home, 0,
+				&m_lastreport_time);
+
+			osvrDeviceTrackerSendPoseTimestamped(m_dev, m_tracker, &hmd, 1,
+				&m_lastreport_time);
+
+			// velocity and acceleration data
+			OSVR_LinearVelocityState lin_vel_state;
+			OSVR_LinearAccelerationState lin_accel_state;
+			decodeVelocity(data + velocity, &lin_vel_state);
+			decodeAcceleration(data + accel, &lin_accel_state);
+
+			osvrDeviceTrackerSendLinearVelocityTimestamped(m_dev, m_tracker, &lin_vel_state, 1, &m_lastreport_time);
+			osvrDeviceTrackerSendLinearAccelerationTimestamped(m_dev, m_tracker, &lin_accel_state, 1, &m_lastreport_time);
+
+			OSVR_AngularVelocityState ang_vel_state;
+			OSVR_AngularAccelerationState ang_accel_state;
+			decodeAngularVelocity(data + ang_velocity, &ang_vel_state);
+			decodeAngularAcceleration(data + ang_accel, &ang_accel_state);
+
+			osvrDeviceTrackerSendAngularVelocityTimestamped(m_dev, m_tracker, &ang_vel_state, 1, &m_lastreport_time);
+			osvrDeviceTrackerSendAngularAccelerationTimestamped(m_dev, m_tracker, &ang_accel_state, 1, &m_lastreport_time);
+
+		}
+		void decodeBaseStationCV1(unsigned char *data) {
+			enum MarkerOffsets {
+				hwversion = 0,	// guessed!
+				fwversion = 1,
+				position = 2,        // This is ONLY for the 2.0/2.1 firmware!(looks like things changed)
+				battery = 2 + 3*2
+			};
+			if (data[hwversion] != 2 || data[fwversion] != 1)
+				// Unknown version
+				return;
+
+			osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, data[battery], 2 * NUM_AXIS,
+				&m_lastreport_time);
+		}
+
+		static const int controllerLength = 3 + (3 + 4) * 2 + 2 + 2 + 1;
+		osvr::pluginkit::DeviceToken m_dev;
+		hid_device* m_hid;
+		OSVR_AnalogDeviceInterface m_analog;
+		OSVR_ButtonDeviceInterface m_button;
+		OSVR_TrackerDeviceInterface m_tracker;
+		OSVR_TimeValue m_lastreport_time;
+		OSVR_Vec3 m_last_home;
+		double m_last_axis[NUM_AXIS];
+	};
+
+	class HardwareDetection {
+	public:
+		HardwareDetection() : m_found(false) {}
+		OSVR_ReturnCode operator()(OSVR_PluginRegContext ctx) {
+
+			// TODO: probe for new devices only
+			if (m_found)
+				return OSVR_RETURN_SUCCESS;
+
+			struct hid_device_info *hid_devices, *cur_dev;
+			hid_devices = hid_enumerate(0x0483, 0x5750);
+			if (!hid_devices)
+				return OSVR_RETURN_FAILURE;
+
+			for (cur_dev = hid_devices; cur_dev; cur_dev = cur_dev->next) {
+				if (wcscmp(cur_dev->manufacturer_string, L"LYRobotix") == 0 &&
+					wcscmp(cur_dev->product_string, L"NOLO") == 0) {
+					/// TODO: Distinguish Headset Marker from other parts?
+					/// Create our device object
+					osvr::pluginkit::registerObjectForDeletion
+						(ctx, new NoloDevice(ctx, cur_dev->path));
+					m_found = true;
+				}
+			}
+
+			hid_free_enumeration(hid_devices);
+			return OSVR_RETURN_SUCCESS;
+		}
+
+	private:
+		/// @brief Have we found our device yet? (this limits the plugin to one
+		/// instance)
+		bool m_found;
+	};
 } // namespace
 
 OSVR_PLUGIN(com_osvr_Nolo) {

--- a/com_osvr_Nolo.cpp
+++ b/com_osvr_Nolo.cpp
@@ -42,454 +42,363 @@ Yann Vernier
 // Anonymous namespace to avoid symbol collision
 namespace {
 
-	// btea_decrypt function
-#include "btea.c"
+  // btea_decrypt function
+  #include "btea.c"
 
-#if 0
-	void hexdump(unsigned char *data, int len) {
-		char fill = std::cout.fill();
-		std::streamsize w = std::cout.width();
-		std::ios_base::fmtflags f = std::cout.flags();
-		for (int i=0; i<len; i++) {
-			std::cout << std::setw(2) << std::setfill('0')
-				<< std::hex << (int)data[i];
-			if (i%8==7)
-				std::cout << " ";
-		}
-		std::cout << std::endl;
-		std::cout.fill(fill);
-		std::cout.width(w);
-		std::cout.flags(f);
-	};
-#endif
+  #if 0
+  void hexdump(unsigned char *data, int len) {
+    char fill = std::cout.fill();
+    std::streamsize w = std::cout.width();
+    std::ios_base::fmtflags f = std::cout.flags();
+    for (int i=0; i<len; i++) {
+      std::cout << std::setw(2) << std::setfill('0')
+		<< std::hex << (int)data[i];
+      if (i%8==7)
+	std::cout << " ";
+    }
+    std::cout << std::endl;
+    std::cout.fill(fill);
+    std::cout.width(w);
+    std::cout.flags(f);
+  };
+  #endif
+  
+const static int NUM_AXIS    = 4;
+const static int NUM_BUTTONS = 6;
+class NoloDevice {
+  public:
+    NoloDevice(OSVR_PluginRegContext ctx,
+	       char *path) {
+        /// Create the initialization options
+        OSVR_DeviceInitOptions opts = osvrDeviceCreateInitOptions(ctx);
 
-	const static int NUM_AXIS = 4;
-	const static int NUM_BUTTONS = 6;
-	class NoloDevice {
-	public:
-		NoloDevice(OSVR_PluginRegContext ctx,
-			char *path) {
-			/// Create the initialization options
-			OSVR_DeviceInitOptions opts = osvrDeviceCreateInitOptions(ctx);
+	std::cout << "Nolo: opening " << path <<
+	  " for " << this << std::endl;
+	m_hid = hid_open_path(path);
 
-			std::cout << "Nolo: opening " << path <<
-				" for " << this << std::endl;
-			m_hid = hid_open_path(path);
+        /// Indicate that we'll want 7 analog channels.
+        //osvrDeviceAnalogConfigure(opts, &m_analog, 2*3+1);
+	// update this to 9 analog channels to include the trigger
+        osvrDeviceAnalogConfigure(opts, &m_analog, NUM_AXIS*2+1);
+	/// And 6 buttons per controller
+        osvrDeviceButtonConfigure(opts, &m_button, 2*NUM_BUTTONS);
+	/// And tracker capability
+        osvrDeviceTrackerConfigure(opts, &m_tracker);
 
-			/// Indicate that we'll want 7 analog channels.
-			//osvrDeviceAnalogConfigure(opts, &m_analog, 2*3+1);
-			// update this to 9 analog channels to include the trigger
-			osvrDeviceAnalogConfigure(opts, &m_analog, NUM_AXIS * 2 + 1);
-			/// And 6 buttons per controller
-			osvrDeviceButtonConfigure(opts, &m_button, 2 * NUM_BUTTONS);
-			/// And tracker capability
-			osvrDeviceTrackerConfigure(opts, &m_tracker);
+        /// Create the device token with the options
+        m_dev.initAsync(ctx, "LYRobotix Nolo", opts);
 
-			/// Create the device token with the options
-			m_dev.initAsync(ctx, "LYRobotix Nolo", opts);
+        /// Send JSON descriptor
+        m_dev.sendJsonDescriptor(com_osvr_Nolo_json);
 
-			/// Send JSON descriptor
-			m_dev.sendJsonDescriptor(com_osvr_Nolo_json);
+        /// Register update callback
+        m_dev.registerUpdateCallback(this);
 
-			/// Register update callback
-			m_dev.registerUpdateCallback(this);
+	memset(&oldreports[0][0], 0, sizeof oldreports);
+    }
+    ~NoloDevice() {
+      std::cout << "Nolo: deleting " << this << std::endl;
+      hid_close(m_hid);
+    }
+  
+    OSVR_ReturnCode update() {
+      unsigned char buf[64];
+      const int cryptwords = (64-4)/4, cryptoffset=1;
+      static const uint32_t key[4] =
+	{0x875bcc51, 0xa7637a66, 0x50960967, 0xf8536c51};
+      uint32_t cryptpart[cryptwords];
+      int i;
 
-			memset(&oldreports[0][0], 0, sizeof oldreports);
-		}
-		~NoloDevice() {
-			std::cout << "Nolo: deleting " << this << std::endl;
-			hid_close(m_hid);
-		}
+      // TODO: timestamp frame received?
+      if (!m_hid)
+	 OSVR_RETURN_FAILURE;
+      //std::cout << "Reading HID data from " << m_hid << std::endl;
+      if(hid_read(m_hid, buf, sizeof buf) != sizeof buf)
+	return OSVR_RETURN_FAILURE;
+      osvrTimeValueGetNow(&m_lastreport_time);
 
-		OSVR_ReturnCode update() {
-			unsigned char buf[64];
-			const int cryptwords = (64 - 4) / 4, cryptoffset = 1;
-			static const uint32_t key[4] =
-			{ 0x875bcc51, 0xa7637a66, 0x50960967, 0xf8536c51 };
-			uint32_t cryptpart[cryptwords];
-			int i;
+      // Check for duplicate reports before decrypting
+      switch (buf[0]) {
+	case 0xa5:
+	case 0xa6:
+	  if (memcmp(oldreports[buf[0]-0xa5], buf, sizeof buf))
+	    memcpy(oldreports[buf[0]-0xa5], buf, sizeof buf);
+	  else
+	    return OSVR_RETURN_SUCCESS;	// Duplicate report
+	  break;
+	default:
+	  return OSVR_RETURN_SUCCESS; // Unknown report
+      }
+      //std::cout << "R ";
+      //hexdump(buf, sizeof buf);
+      // Decrypt encrypted portion
+      for (i=0; i<cryptwords; i++) {
+	cryptpart[i] =
+	  ((uint32_t)buf[cryptoffset+4*i  ])<<0  |
+	  ((uint32_t)buf[cryptoffset+4*i+1])<<8  |
+	  ((uint32_t)buf[cryptoffset+4*i+2])<<16 |
+	  ((uint32_t)buf[cryptoffset+4*i+3])<<24;
+      }
+      btea_decrypt(cryptpart, cryptwords, 1, key);
+      for (i=0; i<cryptwords; i++) {
+	buf[cryptoffset+4*i  ] = cryptpart[i]>>0;
+	buf[cryptoffset+4*i+1] = cryptpart[i]>>8;
+	buf[cryptoffset+4*i+2] = cryptpart[i]>>16;
+	buf[cryptoffset+4*i+3] = cryptpart[i]>>24;
+      }
+      //std::cout << "D ";
+      //hexdump(buf, sizeof buf);
+      
+      switch (buf[0]) {
+      case 0xa5:  // controllers frame
+	decodeControllerCV1(0, buf+1);
+	decodeControllerCV1(1, buf+64-controllerLength);
+	break;
+      case 0xa6:
+	decodeHeadsetMarkerCV1(buf+0x15);
+	decodeBaseStationCV1(buf+0x36);
+	break;
+      }
+      return OSVR_RETURN_SUCCESS;
+    }
 
-			// TODO: timestamp frame received?
-			if (!m_hid)
-				OSVR_RETURN_FAILURE;
-			//std::cout << "Reading HID data from " << m_hid << std::endl;
-			if (hid_read(m_hid, buf, sizeof buf) != sizeof buf)
-				return OSVR_RETURN_FAILURE;
-			osvrTimeValueGetNow(&m_lastreport_time);
-
-			// Check for duplicate reports before decrypting
-			switch (buf[0]) {
-			case 0xa5:
-			case 0xa6:
-				if (memcmp(oldreports[buf[0] - 0xa5], buf, sizeof buf))
-					memcpy(oldreports[buf[0] - 0xa5], buf, sizeof buf);
-				else
-					return OSVR_RETURN_SUCCESS;	// Duplicate report
-				break;
-			default:
-				return OSVR_RETURN_SUCCESS; // Unknown report
-			}
-			//std::cout << "R ";
-			//hexdump(buf, sizeof buf);
-			// Decrypt encrypted portion
-			for (i = 0; i < cryptwords; i++) {
-				cryptpart[i] =
-					((uint32_t)buf[cryptoffset + 4 * i]) << 0 |
-					((uint32_t)buf[cryptoffset + 4 * i + 1]) << 8 |
-					((uint32_t)buf[cryptoffset + 4 * i + 2]) << 16 |
-					((uint32_t)buf[cryptoffset + 4 * i + 3]) << 24;
-			}
-			btea_decrypt(cryptpart, cryptwords, 1, key);
-			for (i = 0; i < cryptwords; i++) {
-				buf[cryptoffset + 4 * i] = cryptpart[i] >> 0;
-				buf[cryptoffset + 4 * i + 1] = cryptpart[i] >> 8;
-				buf[cryptoffset + 4 * i + 2] = cryptpart[i] >> 16;
-				buf[cryptoffset + 4 * i + 3] = cryptpart[i] >> 24;
-			}
-			//std::cout << "D ";
-			//hexdump(buf, sizeof buf);
-
-			switch (buf[0]) {
-			case 0xa5:  // controllers frame
-				decodeControllerCV1(0, buf + 1);
-				decodeControllerCV1(1, buf + 64 - controllerLength);
-				break;
-			case 0xa6:
-				decodeHeadsetMarkerCV1(buf + 0x15);
-				decodeBaseStationCV1(buf + 0x36);
-				break;
-			}
-			return OSVR_RETURN_SUCCESS;
-		}
-
-		// Sets vibration strength in percent
-		int setVibration(unsigned char left,
-			unsigned char right) {
-			unsigned char data[4] = { 0xaa, 0x66, left, right };
-			return hid_write(m_hid, data, sizeof data);
-		}
-
-	private:
-		unsigned char oldreports[2][64];
-		void decodePosition(const unsigned char *data,
+    // Sets vibration strength in percent
+    int setVibration(unsigned char left,
+		     unsigned char right) {
+      unsigned char data[4] = {0xaa, 0x66, left, right};
+      return hid_write(m_hid, data, sizeof data);
+    }
+  
+  private:
+    unsigned char oldreports[2][64];
+    void decodePosition(const unsigned char *data,
 			OSVR_PositionState *pos) {
-			const double scale = 0.0001;
-			osvrVec3SetX(pos, scale * (int16_t)(data[0] << 8 | data[1]));
-			osvrVec3SetY(pos, scale * (int16_t)(data[2] << 8 | data[3]));
-			osvrVec3SetZ(pos, scale *          (data[4] << 8 | data[5]));
+      const double scale = 0.0001;
+      osvrVec3SetX(pos, scale * (int16_t)(data[0]<<8 | data[1]));
+      osvrVec3SetY(pos, scale * (int16_t)(data[2]<<8 | data[3]));
+      osvrVec3SetZ(pos, scale *          (data[4]<<8 | data[5]));
+    }
+    void decodeOrientation(const unsigned char *data,
+			   OSVR_OrientationState *quat) {
+      double w,i,j,k, scale;
+      // CV1 order
+      w = (int16_t)(data[0]<<8 | data[1]);
+      i = (int16_t)(data[2]<<8 | data[3]);
+      j = (int16_t)(data[4]<<8 | data[5]);
+      k = (int16_t)(data[6]<<8 | data[7]);
+      // Normalize (unknown if scale is constant)
+      //scale = 1.0/sqrt(i*i+j*j+k*k+w*w);
+      // Turns out it is fixed point. But the android driver author
+      // either didn't know, or didn't trust it.
+      // Unknown if normalizing it helps OSVR!
+      scale = 1.0 / 16384;
+      //std::cout << "Scale: " << scale << std::endl;
+      w *= scale;
+      i *= scale;
+      j *= scale;
+      k *= scale;
+      // Reorder
+      osvrQuatSetW(quat, w);
+      osvrQuatSetX(quat, i);
+      osvrQuatSetY(quat, k);
+      osvrQuatSetZ(quat, -j);
+    }
+    void decodeControllerCV1(int idx, unsigned char *data) {
+      enum ControllerOffsets {
+	    hwversion   = 0,	// guessed!
+	    fwversion   = 1,
+	    position    = 3,
+	    orientation = 3+3*2,
+	    ofsbuttons  = 3+3*2+4*2,
+	    touchid     = 3+3*2+4*2+1,
+	    touchx      = 3+3*2+4*2+2,
+	    touchy      = 3+3*2+4*2+3,
+	    battery     = 3+3*2+4*2+4,
+      };
+      OSVR_PoseState pose;
+      uint8_t buttons, bit;
+      int trigger_pressed = 0;
+
+      if (data[hwversion] != 2 || data[fwversion] != 1) {
+	// Unknown version
+	/* Happens when controllers aren't on. 
+	std::cout << "Nolo: Unknown controller " << idx
+		  << " version " << (int)data[0] << " " << (int)data[1]
+		  << std::endl;
+	*/
+	return;
+      }
+
+      decodePosition(data+position, &pose.translation);
+      decodeOrientation(data+orientation, &pose.rotation);
+
+      osvrDeviceTrackerSendPoseTimestamped(m_dev, m_tracker, &pose, 2+idx, &m_lastreport_time);
+      
+      buttons = data[ofsbuttons];
+      // TODO: report buttons for both controllers in one call?
+      for (bit=0; bit<NUM_BUTTONS; bit++){
+	osvrDeviceButtonSetValueTimestamped(m_dev, m_button,
+				 (buttons & 1<<bit ? OSVR_BUTTON_PRESSED
+				  : OSVR_BUTTON_NOT_PRESSED), idx*6+bit,
+				 &m_lastreport_time);
+	if(bit == 1){
+	    if(buttons & 1<<bit){
+		trigger_pressed = 1;
+	    }else{
+		trigger_pressed = 0;
+	    }
+	}
+      }
+      // next byte is touch ID bitmask (identical to buttons bit 5)
+
+      // Touch X and Y coordinates
+      // //assumes 0 to 255
+      // normalize from -1 to 1
+      // z = 2*[x - min / (max - min) - 1]
+      // z = 2*(x - 0 / (255 - 0) - 1]
+      // z = 2*(x/255) -1
+      // normalize 0 to 1
+      // x/255
+      double axis_value;
+      if (data[touchid]) {  // Only report touch if there is one
+        axis_value = 2*data[touchx]/255.0 - 1;
+		// Attempt to calibrate, assuming trackpads are only good out to about 60%
+		axis_value *= 1.6667;
+		axis_value = std::fmax(-1, std::fmin(axis_value, 1));
+        // invert axis
+        axis_value *= -1;
+		// Fix edge case by guessing appropriate value (necessary because touchid apparently doesn't always work)
+		if (data[touchx] == 0) { 
+			axis_value = m_last_axis[idx*NUM_AXIS + 0] < 0 ? -1 : 1;
 		}
-		void decodeOrientation(const unsigned char *data,
-			OSVR_OrientationState *quat) {
-			double w, i, j, k, scale;
-			// CV1 order
-			w = (int16_t)(data[0] << 8 | data[1]);
-			i = (int16_t)(data[2] << 8 | data[3]);
-			j = (int16_t)(data[4] << 8 | data[5]);
-			k = (int16_t)(data[6] << 8 | data[7]);
-			// Normalize (unknown if scale is constant)
-			//scale = 1.0/sqrt(i*i+j*j+k*k+w*w);
-			// Turns out it is fixed point. But the android driver author
-			// either didn't know, or didn't trust it.
-			// Unknown if normalizing it helps OSVR!
-			scale = 1.0 / 16384;
-			//std::cout << "Scale: " << scale << std::endl;
-			w *= scale;
-			i *= scale;
-			j *= scale;
-			k *= scale;
-			// Reorder
-			osvrQuatSetW(quat, w);
-			osvrQuatSetX(quat, i);
-			osvrQuatSetY(quat, k);
-			osvrQuatSetZ(quat, -j);
+		m_last_axis[idx*NUM_AXIS + 0] = axis_value;
+        osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, axis_value,   idx*NUM_AXIS+0, &m_lastreport_time);
+
+        axis_value = 2*((int)data[touchy])/255.0 -1;
+		// Attempt to calibrate, assuming trackpads are only good out to about 60%
+		axis_value *= 1.6667;
+		axis_value = std::fmax(-1, std::fmin(axis_value, 1));
+		// invert axis
+        axis_value *= -1;
+		// Fix edge case by guessing appropriate value (necessary because touchid apparently doesn't always work)
+		if (data[touchy] == 0) {
+			axis_value = m_last_axis[idx*NUM_AXIS + 1] < 0 ? -1 : 1;
 		}
-		void decodeVelocity(const unsigned char *data,
-			OSVR_LinearVelocityState *lin_vel) {
-			const double scale = 0.0001;
-			osvrVec3SetX(lin_vel, scale * (int16_t)(data[0] << 8 | data[1]));
-			osvrVec3SetY(lin_vel, scale * (int16_t)(data[2] << 8 | data[3]));
-			osvrVec3SetZ(lin_vel, scale *          (data[4] << 8 | data[5]));
-		}
-		void decodeAcceleration(const unsigned char *data,
-			OSVR_LinearAccelerationState *lin_accel) {
-			const double scale = 0.0001;
-			osvrVec3SetX(lin_accel, scale * (int16_t)(data[0] << 8 | data[1]));
-			osvrVec3SetY(lin_accel, scale * (int16_t)(data[2] << 8 | data[3]));
-			osvrVec3SetZ(lin_accel, scale *          (data[4] << 8 | data[5]));
-		}
-		void decodeAngularVelocity(const unsigned char *data,
-			OSVR_AngularVelocityState *ang_vel) {
-			double i, j, k; 
-			i = (int16_t)(data[0] << 8 | data[1]);
-			j = (int16_t)(data[2] << 8 | data[3]);
-			k = (int16_t)(data[4] << 8 | data[5]);
-			osvrQuatSetX(&ang_vel->incrementalRotation, i);
-			osvrQuatSetY(&ang_vel->incrementalRotation, k);
-			osvrQuatSetZ(&ang_vel->incrementalRotation, -j);
-			// magnitude is rotation in rad/s
-			osvrQuatSetW(&ang_vel->incrementalRotation, sqrt(i*i + j*j + k*k));
-			ang_vel->dt = 1.0; 
-		}
-		void decodeAngularAcceleration(const unsigned char *data,
-			OSVR_AngularAccelerationState *ang_accel) {
-			double i, j, k;
-			i = (int16_t)(data[0] << 8 | data[1]);
-			j = (int16_t)(data[2] << 8 | data[3]);
-			k = (int16_t)(data[4] << 8 | data[5]);
-			osvrQuatSetX(&ang_accel->incrementalRotation, i);
-			osvrQuatSetY(&ang_accel->incrementalRotation, k);
-			osvrQuatSetZ(&ang_accel->incrementalRotation, -j);
-			// magnitude is rotation in rad/s*2
-			osvrQuatSetW(&ang_accel->incrementalRotation, sqrt(i*i + j*j + k*k));
-			ang_accel->dt = 1.0;
-		}
+		m_last_axis[idx*NUM_AXIS + 1] = axis_value;
+        osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, axis_value, idx*NUM_AXIS+1, &m_lastreport_time);
+	  }
+	  else { // Otherwise, report a centered value
+		  axis_value = 0;
+		  osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, axis_value, idx*NUM_AXIS + 0, &m_lastreport_time);
+		  osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, axis_value, idx*NUM_AXIS + 1, &m_lastreport_time);
+	  }
+      // trigger (emulated analog axis)
+      osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, trigger_pressed, idx*NUM_AXIS+2, &m_lastreport_time);
+      // battery level
+      axis_value = data[battery]/255.0; 
+      osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, axis_value, idx*NUM_AXIS+3, &m_lastreport_time);
+    }
+    void decodeHeadsetMarkerCV1(unsigned char *data) {
+      enum MarkerOffsets {
+	    hwversion    = 0,	// guessed!
+	    fwversion    = 1,
+	    position     = 3,
+	    homeposition = 3+3*2,
+	    orientation  = 3+2*3*2+1,
+      };
+      if (data[hwversion] != 2 || data[fwversion] != 1) {
+	/* Happens with corrupt packages (mixed with controller data)
+	std::cout << "Nolo: Unknown headset marker"
+		  << " version " << (int)data[0] << " " << (int)data[1]
+		  << std::endl;
+	*/
+	// Unknown version
+	return;
+      }
 
-		void decodeControllerCV1(int idx, unsigned char *data) {
-			enum ControllerOffsets {
-				hwversion = 0,	// guessed!
-				fwversion = 1,
-				position = 3,
-				orientation = 3 + 3 * 2,
-				ofsbuttons = 3 + 3 * 2 + 4 * 2,
-				touchid = 3 + 3 * 2 + 4 * 2 + 1,
-				touchx = 3 + 3 * 2 + 4 * 2 + 2,
-				touchy = 3 + 3 * 2 + 4 * 2 + 3,
-				battery = 3 + 3 * 2 + 4 * 2 + 4,
-				velocity = 3 + 3 * 2 + 4 * 2 + 5,  // Added with 2.0/2.1 firmware
-				accel = 3 + 3 * 2 + 4 * 2 + 5 + 3 * 2,
-				ang_velocity = 3 + 3 * 2 + 4 * 2 + 5 + 6 * 2,
-				ang_accel = 3 + 3 * 2 + 4 * 2 + 5 + 9 * 2,
-				state = 3 + 3 * 2 + 4 * 2 + 5 + 12 * 2
-			};
-			OSVR_PoseState pose;
-			uint8_t buttons, bit;
-			int trigger_pressed = 0;
+      OSVR_PositionState home;
+      OSVR_PoseState hmd;
+      
+      decodePosition(data+position, &hmd.translation);
+      decodePosition(data+homeposition, &home);
+      decodeOrientation(data+orientation, &hmd.rotation);
 
-			if (data[hwversion] != 2 || data[fwversion] != 1) {
-				// Unknown version
-				/* Happens when controllers aren't on.
-				std::cout << "Nolo: Unknown controller " << idx
-				<< " version " << (int)data[0] << " " << (int)data[1]
-				<< std::endl;
-				*/
-				return;
-			}
+	  // Send button press if home position changed
+	  if (home.data[0] != m_last_home.data[0]) { // An exact comparison on the x value is probably sufficient, if not necessarily proper
+		  osvrDeviceButtonSetValueTimestamped(m_dev, m_button, OSVR_BUTTON_PRESSED, 12, &m_lastreport_time);
+		  m_last_home.data[0] = home.data[0];
+	  }
+	  else {
+		  osvrDeviceButtonSetValueTimestamped(m_dev, m_button, OSVR_BUTTON_NOT_PRESSED, 12, &m_lastreport_time);
+	  }
 
-			decodePosition(data + position, &pose.translation);
-			decodeOrientation(data + orientation, &pose.rotation);
+      // Tracker viewer kept using the home for head.
+      // Something wrong with how they handle the descriptors. 
+      osvrDeviceTrackerSendPositionTimestamped(m_dev, m_tracker, &home, 0,
+		      &m_lastreport_time);
 
-			osvrDeviceTrackerSendPoseTimestamped(m_dev, m_tracker, &pose, 2 + idx, &m_lastreport_time);
+      osvrDeviceTrackerSendPoseTimestamped(m_dev, m_tracker, &hmd, 1,
+		      &m_lastreport_time);
+    }
+    void decodeBaseStationCV1(unsigned char *data) {
+      enum MarkerOffsets {
+	    hwversion = 0,	// guessed!
+	    fwversion = 1,
+	    battery   = 2
+      };
+      if (data[hwversion] != 2 || data[fwversion] != 1)
+	// Unknown version
+	return;
 
-			buttons = data[ofsbuttons];
-			// TODO: report buttons for both controllers in one call?
-			for (bit = 0; bit < NUM_BUTTONS; bit++){
-				osvrDeviceButtonSetValueTimestamped(m_dev, m_button,
-					(buttons & 1 << bit ? OSVR_BUTTON_PRESSED
-					: OSVR_BUTTON_NOT_PRESSED), idx * 6 + bit,
-					&m_lastreport_time);
-				if (bit == 1){
-					if (buttons & 1 << bit){
-						trigger_pressed = 1;
-					}
-					else{
-						trigger_pressed = 0;
-					}
-				}
-			}
-			// next byte is touch ID bitmask (identical to buttons bit 5)
+      osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, data[battery], 2*NUM_AXIS,
+		      &m_lastreport_time);
+    }
+  
+    static const int controllerLength = 3 + (3+4)*2 + 2 + 2 + 1;
+    osvr::pluginkit::DeviceToken m_dev;
+    hid_device* m_hid;
+    OSVR_AnalogDeviceInterface m_analog;
+    OSVR_ButtonDeviceInterface m_button;
+    OSVR_TrackerDeviceInterface m_tracker;
+    OSVR_TimeValue m_lastreport_time;
+	OSVR_Vec3 m_last_home;
+	double m_last_axis[NUM_AXIS];
+};
 
-			// Touch X and Y coordinates
-			// //assumes 0 to 255
-			// normalize from -1 to 1
-			// z = 2*[x - min / (max - min) - 1]
-			// z = 2*(x - 0 / (255 - 0) - 1]
-			// z = 2*(x/255) -1
-			// normalize 0 to 1
-			// x/255
-			double axis_value;
-			if (data[touchid]) {  // Only report touch if there is one
-				axis_value = 2 * data[touchx] / 255.0 - 1;
-				// Attempt to calibrate, assuming trackpads are only good out to about 60%
-				axis_value *= 1.6667;
-				axis_value = std::fmax(-1, std::fmin(axis_value, 1));
-				// invert axis
-				axis_value *= -1;
-				// Fix edge case by guessing appropriate value (necessary because touchid apparently doesn't always work)
-				if (data[touchx] == 0) {
-					axis_value = m_last_axis[idx*NUM_AXIS + 0] < 0 ? -1 : 1;
-				}
-				m_last_axis[idx*NUM_AXIS + 0] = axis_value;
-				osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, axis_value, idx*NUM_AXIS + 0, &m_lastreport_time);
+class HardwareDetection {
+  public:
+    HardwareDetection() : m_found(false) {}
+    OSVR_ReturnCode operator()(OSVR_PluginRegContext ctx) {
 
-				axis_value = 2 * ((int)data[touchy]) / 255.0 - 1;
-				// Attempt to calibrate, assuming trackpads are only good out to about 60%
-				axis_value *= 1.6667;
-				axis_value = std::fmax(-1, std::fmin(axis_value, 1));
-				// invert axis
-				axis_value *= -1;
-				// Fix edge case by guessing appropriate value (necessary because touchid apparently doesn't always work)
-				if (data[touchy] == 0) {
-					axis_value = m_last_axis[idx*NUM_AXIS + 1] < 0 ? -1 : 1;
-				}
-				m_last_axis[idx*NUM_AXIS + 1] = axis_value;
-				osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, axis_value, idx*NUM_AXIS + 1, &m_lastreport_time);
-			}
-			else { // Otherwise, report a centered value
-				axis_value = 0;
-				osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, axis_value, idx*NUM_AXIS + 0, &m_lastreport_time);
-				osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, axis_value, idx*NUM_AXIS + 1, &m_lastreport_time);
-			}
-			// trigger (emulated analog axis)
-			osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, trigger_pressed, idx*NUM_AXIS + 2, &m_lastreport_time);
-			// battery level
-			axis_value = data[battery] / 255.0;
-			osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, axis_value, idx*NUM_AXIS + 3, &m_lastreport_time);
+      // TODO: probe for new devices only
+      if (m_found)
+	return OSVR_RETURN_SUCCESS;
 
-			// velocity and acceleration data
-			OSVR_LinearVelocityState lin_vel_state;
-			OSVR_LinearAccelerationState lin_accel_state; 
-			decodeVelocity(data + velocity, &lin_vel_state);
-			decodeAcceleration(data + accel, &lin_accel_state);
+      struct hid_device_info *hid_devices, *cur_dev;
+      hid_devices = hid_enumerate(0x0483, 0x5750);
+      if (!hid_devices)
+	return OSVR_RETURN_FAILURE;
 
-			osvrDeviceTrackerSendLinearVelocityTimestamped(m_dev, m_tracker, &lin_vel_state, 2 + idx, &m_lastreport_time);
-			osvrDeviceTrackerSendLinearAccelerationTimestamped(m_dev, m_tracker, &lin_accel_state, 2 + idx, &m_lastreport_time);
+      for (cur_dev = hid_devices; cur_dev; cur_dev = cur_dev->next) {
+	if (wcscmp(cur_dev->manufacturer_string, L"LYRobotix")==0 &&
+	    wcscmp(cur_dev->product_string, L"NOLO")==0) {
+	  /// TODO: Distinguish Headset Marker from other parts?
+	  /// Create our device object
+	  osvr::pluginkit::registerObjectForDeletion
+	    (ctx, new NoloDevice(ctx, cur_dev->path));
+	  m_found = true;
+	}
+      }
+      
+      hid_free_enumeration(hid_devices);
+      return OSVR_RETURN_SUCCESS;
+    }
 
-			OSVR_AngularVelocityState ang_vel_state; 
-			OSVR_AngularAccelerationState ang_accel_state; 
-			decodeAngularVelocity(data + ang_velocity, &ang_vel_state);
-			decodeAngularAcceleration(data + ang_accel, &ang_accel_state);
-
-			osvrDeviceTrackerSendAngularVelocityTimestamped(m_dev, m_tracker, &ang_vel_state, 2 + idx, &m_lastreport_time);
-			osvrDeviceTrackerSendAngularAccelerationTimestamped(m_dev, m_tracker, &ang_accel_state, 2 + idx, &m_lastreport_time);
-
-		    // should we be using the "state" information for anything? 
-
-		}
-		void decodeHeadsetMarkerCV1(unsigned char *data) {
-			enum MarkerOffsets {
-				hwversion = 0,	// guessed!
-				fwversion = 1,
-				position = 3,
-				homeposition = 3 + 3 * 2,
-				orientation = 3 + 2 * 3 * 2 + 1,       // why the +1 offset here? (firmware dependent?)
-				velocity = 3 + 2 * 3 * 2 + 1 + 4 * 2,  // Added with 2.0/2.1 firmware
-				accel = 3 + 2 * 3 * 2 + 1 + 7 * 2,
-				ang_velocity = 3 + 2 * 3 * 2 + 1 + 10 * 2,
-				ang_accel = 3 + 2 * 3 * 2 + 1 + 13 * 2,
-				state = 3 + 2 * 3 * 2 + 1 + 16 * 2
-			};
-			if (data[hwversion] != 2 || data[fwversion] != 1) {
-				/* Happens with corrupt packages (mixed with controller data)
-				std::cout << "Nolo: Unknown headset marker"
-				<< " version " << (int)data[0] << " " << (int)data[1]
-				<< std::endl;
-				*/
-				// Unknown version
-				return;
-			}
-
-			OSVR_PositionState home;
-			OSVR_PoseState hmd;
-
-			decodePosition(data + position, &hmd.translation);
-			decodePosition(data + homeposition, &home);
-			decodeOrientation(data + orientation, &hmd.rotation);
-
-			// Send button press if home position changed
-			if (home.data[0] != m_last_home.data[0]) { // An exact comparison on the x value is probably sufficient, if not necessarily proper
-				osvrDeviceButtonSetValueTimestamped(m_dev, m_button, OSVR_BUTTON_PRESSED, 12, &m_lastreport_time);
-				m_last_home.data[0] = home.data[0];
-			}
-			else {
-				osvrDeviceButtonSetValueTimestamped(m_dev, m_button, OSVR_BUTTON_NOT_PRESSED, 12, &m_lastreport_time);
-			}
-
-			// Tracker viewer kept using the home for head.
-			// Something wrong with how they handle the descriptors. 
-			osvrDeviceTrackerSendPositionTimestamped(m_dev, m_tracker, &home, 0,
-				&m_lastreport_time);
-
-			osvrDeviceTrackerSendPoseTimestamped(m_dev, m_tracker, &hmd, 1,
-				&m_lastreport_time);
-
-			// velocity and acceleration data
-			OSVR_LinearVelocityState lin_vel_state;
-			OSVR_LinearAccelerationState lin_accel_state;
-			decodeVelocity(data + velocity, &lin_vel_state);
-			decodeAcceleration(data + accel, &lin_accel_state);
-
-			osvrDeviceTrackerSendLinearVelocityTimestamped(m_dev, m_tracker, &lin_vel_state, 1, &m_lastreport_time);
-			osvrDeviceTrackerSendLinearAccelerationTimestamped(m_dev, m_tracker, &lin_accel_state, 1, &m_lastreport_time);
-
-			OSVR_AngularVelocityState ang_vel_state;
-			OSVR_AngularAccelerationState ang_accel_state;
-			decodeAngularVelocity(data + ang_velocity, &ang_vel_state);
-			decodeAngularAcceleration(data + ang_accel, &ang_accel_state);
-
-			osvrDeviceTrackerSendAngularVelocityTimestamped(m_dev, m_tracker, &ang_vel_state, 1, &m_lastreport_time);
-			osvrDeviceTrackerSendAngularAccelerationTimestamped(m_dev, m_tracker, &ang_accel_state, 1, &m_lastreport_time);
-
-		}
-		void decodeBaseStationCV1(unsigned char *data) {
-			enum MarkerOffsets {
-				hwversion = 0,	// guessed!
-				fwversion = 1,
-				position = 2,        // This is ONLY for the 2.0/2.1 firmware!(looks like things changed)
-				battery = 2 + 3*2
-			};
-			if (data[hwversion] != 2 || data[fwversion] != 1)
-				// Unknown version
-				return;
-
-			osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, data[battery], 2 * NUM_AXIS,
-				&m_lastreport_time);
-		}
-
-		static const int controllerLength = 3 + (3 + 4) * 2 + 2 + 2 + 1;
-		osvr::pluginkit::DeviceToken m_dev;
-		hid_device* m_hid;
-		OSVR_AnalogDeviceInterface m_analog;
-		OSVR_ButtonDeviceInterface m_button;
-		OSVR_TrackerDeviceInterface m_tracker;
-		OSVR_TimeValue m_lastreport_time;
-		OSVR_Vec3 m_last_home;
-		double m_last_axis[NUM_AXIS];
-	};
-
-	class HardwareDetection {
-	public:
-		HardwareDetection() : m_found(false) {}
-		OSVR_ReturnCode operator()(OSVR_PluginRegContext ctx) {
-
-			// TODO: probe for new devices only
-			if (m_found)
-				return OSVR_RETURN_SUCCESS;
-
-			struct hid_device_info *hid_devices, *cur_dev;
-			hid_devices = hid_enumerate(0x0483, 0x5750);
-			if (!hid_devices)
-				return OSVR_RETURN_FAILURE;
-
-			for (cur_dev = hid_devices; cur_dev; cur_dev = cur_dev->next) {
-				if (wcscmp(cur_dev->manufacturer_string, L"LYRobotix") == 0 &&
-					wcscmp(cur_dev->product_string, L"NOLO") == 0) {
-					/// TODO: Distinguish Headset Marker from other parts?
-					/// Create our device object
-					osvr::pluginkit::registerObjectForDeletion
-						(ctx, new NoloDevice(ctx, cur_dev->path));
-					m_found = true;
-				}
-			}
-
-			hid_free_enumeration(hid_devices);
-			return OSVR_RETURN_SUCCESS;
-		}
-
-	private:
-		/// @brief Have we found our device yet? (this limits the plugin to one
-		/// instance)
-		bool m_found;
-	};
+  private:
+    /// @brief Have we found our device yet? (this limits the plugin to one
+    /// instance)
+    bool m_found;
+};
 } // namespace
 
 OSVR_PLUGIN(com_osvr_Nolo) {

--- a/com_osvr_Nolo.json
+++ b/com_osvr_Nolo.json
@@ -22,12 +22,12 @@
         {
           "min": -1,
           "max": 1,
-          "rest": 1
+          "rest": 0
         },
         {
           "min": -1,
           "max": 1,
-          "rest": 1
+          "rest": 0
         },
         {
           "min": 0,
@@ -42,12 +42,12 @@
         {
           "min": -1,
           "max": 1,
-          "rest": 1 
+          "rest": 0 
         },
         {
           "min": -1,
           "max": 1,
-          "rest": 1
+          "rest": 0
         },
         {
           "min": 0,

--- a/com_osvr_Nolo.json
+++ b/com_osvr_Nolo.json
@@ -9,7 +9,11 @@
       "bounded": true,
       "position": true,
       "orientation": true,
-      "count": 4,
+      "linearVelocity":  true,
+      "angularVelocity":  true,
+      "linearAcceleration":  true,
+      "angularAcceleration":  true, 
+      "count": 8,
       "traits": [{"orientation": false}]
     },
     "analog": {

--- a/com_osvr_Nolo.json
+++ b/com_osvr_Nolo.json
@@ -63,7 +63,7 @@
       ]
     },
     "button": {
-      "count": 14
+      "count": 13
     }
   },
   "semantic": {

--- a/com_osvr_Nolo_win.cpp
+++ b/com_osvr_Nolo_win.cpp
@@ -140,15 +140,15 @@ namespace {
 			}
 
 			osvrTimeValueGetNow(&device.m_lastreport_time);
-			static int i = 0;
-			if (i > 1000) {
-				std::cout << device.m_lastreport_time.seconds << " " << device.m_lastreport_time.microseconds << "\n";
-				std::cout << data.right_Controller_Data.vecVelocity.x << "," << data.right_Controller_Data.vecVelocity.y << "," << data.right_Controller_Data.vecVelocity.z << "\n";
-				std::cout << data.left_Controller_Data.vecVelocity.x << "," << data.left_Controller_Data.vecVelocity.y << "," << data.left_Controller_Data.vecVelocity.z << "\n";
-				std::cout.flush();
-				i = 0;
-			}
-			++i;
+			//static int i = 0;
+			//if (i > 1000) {
+			//	std::cout << device.m_lastreport_time.seconds << " " << device.m_lastreport_time.microseconds << "\n";
+			//	std::cout << data.right_Controller_Data.vecVelocity.x << "," << data.right_Controller_Data.vecVelocity.y << "," << data.right_Controller_Data.vecVelocity.z << "\n";
+			//	std::cout << data.left_Controller_Data.vecVelocity.x << "," << data.left_Controller_Data.vecVelocity.y << "," << data.left_Controller_Data.vecVelocity.z << "\n";
+			//	std::cout.flush();
+			//	i = 0;
+			//}
+			//++i;
 
 			double translationScale = 1.0f;
 
@@ -218,19 +218,6 @@ namespace {
 			osvrDeviceAnalogSetValueTimestamped(device.m_dev, device.m_analog, leftTrigger, 2, &device.m_lastreport_time);
 			osvrDeviceAnalogSetValueTimestamped(device.m_dev, device.m_analog, rightTrigger, 6, &device.m_lastreport_time);
 
-			/*OSVR_ButtonState buttonValues[12];
-
-			for (unsigned int i = 0; i < 5; ++i) {
-				buttonValues[i] = ((leftButtons & (2 ^ i)) == (2 ^ i)) ? OSVR_BUTTON_PRESSED : OSVR_BUTTON_NOT_PRESSED;
-			}
-			for (unsigned int i = 6; i < 11; ++i) {
-				unsigned int j = i - 6;
-				buttonValues[i] = ((rightButtons & (2 ^ j)) == (2 ^ j)) ? OSVR_BUTTON_PRESSED : OSVR_BUTTON_NOT_PRESSED;
-			}
-			buttonValues[5] = data.left_Controller_Data.ControllerTouched;
-			buttonValues[11] = data.right_Controller_Data.ControllerTouched;
-			osvrDeviceButtonSetValuesTimestamped(device.m_dev, device.m_button, buttonValues, 12, &device.m_lastreport_time);*/
-
 			/*
 			Report Analog Touchpad
 			*/
@@ -286,7 +273,7 @@ namespace {
 			double velocityScale = 1.0f;
 			osvrVec3SetX(&vel.linearVelocity, velocityScale * data.x);
 			osvrVec3SetY(&vel.linearVelocity, velocityScale * data.y);
-			osvrVec3SetZ(&vel.linearVelocity, velocityScale * -data.z);
+			osvrVec3SetZ(&vel.linearVelocity, velocityScale * data.z);
 			vel.linearVelocityValid = true;
 		}
 

--- a/com_osvr_Nolo_win.cpp
+++ b/com_osvr_Nolo_win.cpp
@@ -191,7 +191,7 @@ namespace {
 			int leftTrigger = 0;
 			int rightTrigger = 0;
 
-			for (unsigned int bid = 0; bid < 5; ++bid) {
+			for (unsigned int bid = 0; bid < NUM_BUTTONS; ++bid) {
 				OSVR_ButtonState leftValue = leftButtons & 1 << bid ? OSVR_BUTTON_PRESSED : OSVR_BUTTON_NOT_PRESSED;
 				OSVR_ButtonState rightValue = rightButtons & 1 << bid ? OSVR_BUTTON_PRESSED : OSVR_BUTTON_NOT_PRESSED;
 				if (bid == 1) {
@@ -199,7 +199,7 @@ namespace {
 					rightTrigger = (int)rightValue;
 				}
 				osvrDeviceButtonSetValueTimestamped(device.m_dev, device.m_button, leftValue, bid, &device.m_lastreport_time);
-				osvrDeviceButtonSetValueTimestamped(device.m_dev, device.m_button, rightValue, bid+6, &device.m_lastreport_time);
+				osvrDeviceButtonSetValueTimestamped(device.m_dev, device.m_button, rightValue, bid+NUM_BUTTONS, &device.m_lastreport_time);
 			}
 			osvrDeviceAnalogSetValueTimestamped(device.m_dev, device.m_analog, leftTrigger, 2, &device.m_lastreport_time);
 			osvrDeviceAnalogSetValueTimestamped(device.m_dev, device.m_analog, rightTrigger, 6, &device.m_lastreport_time);

--- a/com_osvr_Nolo_win.cpp
+++ b/com_osvr_Nolo_win.cpp
@@ -149,17 +149,17 @@ namespace {
 
 			device.SetPosition(home, data.hmdData.HMDInitPosition);
 			device.SetPose(hmd, data.hmdData.HMDPosition, data.hmdData.HMDRotation);
-			device.SetVelocity(hmdVel, data.hmdData.vecVelocity, data.hmdData.vecAngularVelocity);
-			device.SetAcceleration(hmdAcc, data.hmdData.vecAcceleration, data.hmdData.vecAngularAcceleration);
+			//device.SetVelocity(hmdVel, data.hmdData.vecVelocity, data.hmdData.vecAngularVelocity);
+			//device.SetAcceleration(hmdAcc, data.hmdData.vecAcceleration, data.hmdData.vecAngularAcceleration);
 
 			osvrDeviceTrackerSendPositionTimestamped(device.m_dev, device.m_tracker, &home, 0, &device.m_lastreport_time);
 			osvrDeviceTrackerSendPoseTimestamped(device.m_dev, device.m_tracker, &hmd, 1, &device.m_lastreport_time);
-			osvrDeviceTrackerSendVelocityTimestamped(device.m_dev, device.m_tracker, &hmdVel, 1, &device.m_lastreport_time);
-			osvrDeviceTrackerSendAccelerationTimestamped(device.m_dev, device.m_tracker, &hmdAcc, 1, &device.m_lastreport_time);
+			//osvrDeviceTrackerSendVelocityTimestamped(device.m_dev, device.m_tracker, &hmdVel, 1, &device.m_lastreport_time);
+			//osvrDeviceTrackerSendAccelerationTimestamped(device.m_dev, device.m_tracker, &hmdAcc, 1, &device.m_lastreport_time);
 
-			/*
-			Report Controller Pose
-			*/
+			///*
+			//Report Controller Pose
+			//*/
 			OSVR_PoseState leftController;
 			OSVR_VelocityState leftVel;
 			OSVR_AccelerationState leftAcc;
@@ -169,20 +169,20 @@ namespace {
 			OSVR_AccelerationState rightAcc;
 
 			device.SetPose(leftController, data.left_Controller_Data.ControllerPosition, data.left_Controller_Data.ControllerRotation);
-			device.SetVelocity(leftVel, data.left_Controller_Data.vecVelocity, data.left_Controller_Data.vecAngularVelocity);
-			device.SetAcceleration(leftAcc, data.left_Controller_Data.vecAcceleration, data.left_Controller_Data.vecAngularAcceleration);
+			//device.SetVelocity(leftVel, data.left_Controller_Data.vecVelocity, data.left_Controller_Data.vecAngularVelocity);
+			//device.SetAcceleration(leftAcc, data.left_Controller_Data.vecAcceleration, data.left_Controller_Data.vecAngularAcceleration);
 
 			osvrDeviceTrackerSendPoseTimestamped(device.m_dev, device.m_tracker, &leftController, 2, &device.m_lastreport_time);
-			osvrDeviceTrackerSendVelocityTimestamped(device.m_dev, device.m_tracker, &leftVel, 2, &device.m_lastreport_time);
-			osvrDeviceTrackerSendAccelerationTimestamped(device.m_dev, device.m_tracker, &leftAcc, 2, &device.m_lastreport_time);
+			//osvrDeviceTrackerSendVelocityTimestamped(device.m_dev, device.m_tracker, &leftVel, 2, &device.m_lastreport_time);
+			//osvrDeviceTrackerSendAccelerationTimestamped(device.m_dev, device.m_tracker, &leftAcc, 2, &device.m_lastreport_time);
 
 			device.SetPose(rightController, data.right_Controller_Data.ControllerPosition, data.right_Controller_Data.ControllerRotation);
-			device.SetVelocity(rightVel, data.right_Controller_Data.vecVelocity, data.right_Controller_Data.vecAngularVelocity);
-			device.SetAcceleration(rightAcc, data.right_Controller_Data.vecAcceleration, data.right_Controller_Data.vecAngularAcceleration);
+			//device.SetVelocity(rightVel, data.right_Controller_Data.vecVelocity, data.right_Controller_Data.vecAngularVelocity);
+			//device.SetAcceleration(rightAcc, data.right_Controller_Data.vecAcceleration, data.right_Controller_Data.vecAngularAcceleration);
 
 			osvrDeviceTrackerSendPoseTimestamped(device.m_dev, device.m_tracker, &rightController, 3, &device.m_lastreport_time);
-			osvrDeviceTrackerSendVelocityTimestamped(device.m_dev, device.m_tracker, &rightVel, 3, &device.m_lastreport_time);
-			osvrDeviceTrackerSendAccelerationTimestamped(device.m_dev, device.m_tracker, &rightAcc, 3, &device.m_lastreport_time);
+			//osvrDeviceTrackerSendVelocityTimestamped(device.m_dev, device.m_tracker, &rightVel, 3, &device.m_lastreport_time);
+			//osvrDeviceTrackerSendAccelerationTimestamped(device.m_dev, device.m_tracker, &rightAcc, 3, &device.m_lastreport_time);
 
 			/*
 			Report Buttons

--- a/com_osvr_Nolo_win.cpp
+++ b/com_osvr_Nolo_win.cpp
@@ -134,14 +134,15 @@ namespace {
 			}
 
 			osvrTimeValueGetNow(&device.m_lastreport_time);
-			//static int i = 0;
-			//if (i > 10000) {
-			//	std::cout << device.m_lastreport_time.seconds << " " << device.m_lastreport_time.microseconds << "\n";
-			//	std::cout << data.hmdData.HMDPosition.x << "," << data.hmdData.HMDPosition.y << "," << data.hmdData.HMDPosition.z << "\n";
-			//	std::cout.flush();
-			//	i = 0;
-			//}
-			//++i;
+			static int i = 0;
+			if (i > 1000) {
+				std::cout << device.m_lastreport_time.seconds << " " << device.m_lastreport_time.microseconds << "\n";
+				std::cout << data.right_Controller_Data.vecVelocity.x << "," << data.right_Controller_Data.vecVelocity.y << "," << data.right_Controller_Data.vecVelocity.z << "\n";
+				std::cout << data.left_Controller_Data.vecVelocity.x << "," << data.left_Controller_Data.vecVelocity.y << "," << data.left_Controller_Data.vecVelocity.z << "\n";
+				std::cout.flush();
+				i = 0;
+			}
+			++i;
 
 			double translationScale = 1.0f;
 

--- a/com_osvr_Nolo_win.cpp
+++ b/com_osvr_Nolo_win.cpp
@@ -212,14 +212,20 @@ namespace {
 			/*
 			Report Analog Touchpad
 			*/
-			double leftx = data.left_Controller_Data.ControllerTouchAxis.x;
-			double lefty = data.left_Controller_Data.ControllerTouchAxis.y;
-			double rightx = data.right_Controller_Data.ControllerTouchAxis.x;
-			double righty = data.right_Controller_Data.ControllerTouchAxis.y;
-			osvrDeviceAnalogSetValueTimestamped(device.m_dev, device.m_analog, leftx, 0, &device.m_lastreport_time);
-			osvrDeviceAnalogSetValueTimestamped(device.m_dev, device.m_analog, lefty, 1, &device.m_lastreport_time);
-			osvrDeviceAnalogSetValueTimestamped(device.m_dev, device.m_analog, rightx, 4, &device.m_lastreport_time);
-			osvrDeviceAnalogSetValueTimestamped(device.m_dev, device.m_analog, righty, 5, &device.m_lastreport_time);
+			if (data.left_Controller_Data.ControllerTouched){
+				double leftx = data.left_Controller_Data.ControllerTouchAxis.x;
+				double lefty = data.left_Controller_Data.ControllerTouchAxis.y;
+				osvrDeviceAnalogSetValueTimestamped(device.m_dev, device.m_analog, leftx, 0, &device.m_lastreport_time);
+				osvrDeviceAnalogSetValueTimestamped(device.m_dev, device.m_analog, lefty, 1, &device.m_lastreport_time);
+			}
+
+			if (data.right_Controller_Data.ControllerTouched){
+				double rightx = data.right_Controller_Data.ControllerTouchAxis.x;
+				double righty = data.right_Controller_Data.ControllerTouchAxis.y;
+				osvrDeviceAnalogSetValueTimestamped(device.m_dev, device.m_analog, rightx, 4, &device.m_lastreport_time);
+				osvrDeviceAnalogSetValueTimestamped(device.m_dev, device.m_analog, righty, 5, &device.m_lastreport_time);
+			}
+
 			/*
 			Report Status
 			*/

--- a/com_osvr_Nolo_win.cpp
+++ b/com_osvr_Nolo_win.cpp
@@ -42,27 +42,6 @@ Nanospork
 // Anonymous namespace to avoid symbol collision
 namespace {
 
-	// btea_decrypt function
-#include "btea.c"
-
-#if 0
-	void hexdump(unsigned char *data, int len) {
-		char fill = std::cout.fill();
-		std::streamsize w = std::cout.width();
-		std::ios_base::fmtflags f = std::cout.flags();
-		for (int i = 0; i<len; i++) {
-			std::cout << std::setw(2) << std::setfill('0')
-				<< std::hex << (int)data[i];
-			if (i % 8 == 7)
-				std::cout << " ";
-		}
-		std::cout << std::endl;
-		std::cout.fill(fill);
-		std::cout.width(w);
-		std::cout.flags(f);
-	};
-#endif
-
 	const static int NUM_AXIS = 4;
 	const static int NUM_BUTTONS = 6;
 	class NoloDevice {

--- a/com_osvr_Nolo_win.cpp
+++ b/com_osvr_Nolo_win.cpp
@@ -207,16 +207,13 @@ namespace {
 			/*
 			Report Analog Touchpad
 			*/
-			static double m_last_axis[2 * NUM_AXIS];
+			static double m_last_axis[4] = { 0.0, 0.0, 0.0, 0.0 }; 
 			static bool not_touched[2] = { true, true }; 
 
 			if (data.left_Controller_Data.ControllerTouched){
 				float leftx = data.left_Controller_Data.ControllerTouchAxis.x;
 				float lefty = data.left_Controller_Data.ControllerTouchAxis.y;
 				
-				leftx = std::fmax(-1.0, std::fmin(leftx, 1.0));
-				lefty = std::fmax(-1.0, std::fmin(lefty, 1.0));
-
 				if ((m_last_axis[0] != leftx) || (m_last_axis[1] != lefty)){
 					osvrDeviceAnalogSetValueTimestamped(device.m_dev, device.m_analog, leftx, 0, &device.m_lastreport_time);
 					osvrDeviceAnalogSetValueTimestamped(device.m_dev, device.m_analog, lefty, 1, &device.m_lastreport_time);
@@ -224,7 +221,6 @@ namespace {
 
 				m_last_axis[0] = leftx;
 				m_last_axis[1] = lefty;
-
 				not_touched[0] = true; 
 
 			}
@@ -241,17 +237,13 @@ namespace {
 				float rightx = data.right_Controller_Data.ControllerTouchAxis.x;
 				float righty = data.right_Controller_Data.ControllerTouchAxis.y;
 
-				rightx = std::fmax(-1.0, std::fmin(rightx, 1.0));
-				righty = std::fmax(-1.0, std::fmin(righty, 1.0));
-
-				if ((m_last_axis[4] != rightx) || (m_last_axis[5] != righty)){
+				if ((m_last_axis[2] != rightx) || (m_last_axis[3] != righty)){
 					osvrDeviceAnalogSetValueTimestamped(device.m_dev, device.m_analog, rightx, 4, &device.m_lastreport_time);
 					osvrDeviceAnalogSetValueTimestamped(device.m_dev, device.m_analog, righty, 5, &device.m_lastreport_time);
 				}
 
-				m_last_axis[4] = rightx;
-				m_last_axis[5] = righty;
-
+				m_last_axis[2] = rightx;
+				m_last_axis[3] = righty;
 				not_touched[1] = true;
 
 			}

--- a/com_osvr_Nolo_win.cpp
+++ b/com_osvr_Nolo_win.cpp
@@ -97,12 +97,18 @@ namespace {
 			NOLO::registerDisConnectCallBack(disconnectNolo, this);
 			NOLO::registerConnectSuccessCallBack(connectNolo, this);
 			NOLO::registerExpandDataNotifyCallBack(expandDataNotify, this);
-			NOLO::registerNoloDataNotifyCallBack(noloDataNotify, this);
+			// Switch to polling structure to avoid strange SteamVR bug.
+			//NOLO::registerNoloDataNotifyCallBack(noloDataNotify, this);
 			NOLO::search_Nolo_Device();
 		}
 		~NoloDevice() {
 			std::cout << "Nolo: deleting " << this << std::endl;
 			NOLO::close_Nolo_Device();
+		}
+		OSVR_ReturnCode update() {
+			// Switch to polling structure to avoid strange SteamVR bug.
+			noloDataNotify(NOLO::get_Nolo_NoloData(), this);
+			return OSVR_RETURN_SUCCESS;
 		}
 
 		static void disconnectNolo(void* context) {
@@ -128,14 +134,14 @@ namespace {
 			}
 
 			osvrTimeValueGetNow(&device.m_lastreport_time);
-			static int i = 0;
-			if (i > 10) {
-				std::cout << device.m_lastreport_time.seconds << " " << device.m_lastreport_time.microseconds << "\n";
-				std::cout << data.hmdData.HMDPosition.x << "," << data.hmdData.HMDPosition.y << "," << data.hmdData.HMDPosition.z << "\n";
-				std::cout.flush();
-				i = 0;
-			}
-			++i;
+			//static int i = 0;
+			//if (i > 10000) {
+			//	std::cout << device.m_lastreport_time.seconds << " " << device.m_lastreport_time.microseconds << "\n";
+			//	std::cout << data.hmdData.HMDPosition.x << "," << data.hmdData.HMDPosition.y << "," << data.hmdData.HMDPosition.z << "\n";
+			//	std::cout.flush();
+			//	i = 0;
+			//}
+			//++i;
 
 			double translationScale = 1.0f;
 
@@ -149,13 +155,13 @@ namespace {
 
 			device.SetPosition(home, data.hmdData.HMDInitPosition);
 			device.SetPose(hmd, data.hmdData.HMDPosition, data.hmdData.HMDRotation);
-			//device.SetVelocity(hmdVel, data.hmdData.vecVelocity, data.hmdData.vecAngularVelocity);
-			//device.SetAcceleration(hmdAcc, data.hmdData.vecAcceleration, data.hmdData.vecAngularAcceleration);
+			device.SetVelocity(hmdVel, data.hmdData.vecVelocity, data.hmdData.vecAngularVelocity);
+			device.SetAcceleration(hmdAcc, data.hmdData.vecAcceleration, data.hmdData.vecAngularAcceleration);
 
 			osvrDeviceTrackerSendPositionTimestamped(device.m_dev, device.m_tracker, &home, 0, &device.m_lastreport_time);
 			osvrDeviceTrackerSendPoseTimestamped(device.m_dev, device.m_tracker, &hmd, 1, &device.m_lastreport_time);
-			//osvrDeviceTrackerSendVelocityTimestamped(device.m_dev, device.m_tracker, &hmdVel, 1, &device.m_lastreport_time);
-			//osvrDeviceTrackerSendAccelerationTimestamped(device.m_dev, device.m_tracker, &hmdAcc, 1, &device.m_lastreport_time);
+			osvrDeviceTrackerSendVelocityTimestamped(device.m_dev, device.m_tracker, &hmdVel, 1, &device.m_lastreport_time);
+			osvrDeviceTrackerSendAccelerationTimestamped(device.m_dev, device.m_tracker, &hmdAcc, 1, &device.m_lastreport_time);
 
 			///*
 			//Report Controller Pose
@@ -169,20 +175,20 @@ namespace {
 			OSVR_AccelerationState rightAcc;
 
 			device.SetPose(leftController, data.left_Controller_Data.ControllerPosition, data.left_Controller_Data.ControllerRotation);
-			//device.SetVelocity(leftVel, data.left_Controller_Data.vecVelocity, data.left_Controller_Data.vecAngularVelocity);
-			//device.SetAcceleration(leftAcc, data.left_Controller_Data.vecAcceleration, data.left_Controller_Data.vecAngularAcceleration);
+			device.SetVelocity(leftVel, data.left_Controller_Data.vecVelocity, data.left_Controller_Data.vecAngularVelocity);
+			device.SetAcceleration(leftAcc, data.left_Controller_Data.vecAcceleration, data.left_Controller_Data.vecAngularAcceleration);
 
 			osvrDeviceTrackerSendPoseTimestamped(device.m_dev, device.m_tracker, &leftController, 2, &device.m_lastreport_time);
-			//osvrDeviceTrackerSendVelocityTimestamped(device.m_dev, device.m_tracker, &leftVel, 2, &device.m_lastreport_time);
-			//osvrDeviceTrackerSendAccelerationTimestamped(device.m_dev, device.m_tracker, &leftAcc, 2, &device.m_lastreport_time);
+			osvrDeviceTrackerSendVelocityTimestamped(device.m_dev, device.m_tracker, &leftVel, 2, &device.m_lastreport_time);
+			osvrDeviceTrackerSendAccelerationTimestamped(device.m_dev, device.m_tracker, &leftAcc, 2, &device.m_lastreport_time);
 
 			device.SetPose(rightController, data.right_Controller_Data.ControllerPosition, data.right_Controller_Data.ControllerRotation);
-			//device.SetVelocity(rightVel, data.right_Controller_Data.vecVelocity, data.right_Controller_Data.vecAngularVelocity);
-			//device.SetAcceleration(rightAcc, data.right_Controller_Data.vecAcceleration, data.right_Controller_Data.vecAngularAcceleration);
+			device.SetVelocity(rightVel, data.right_Controller_Data.vecVelocity, data.right_Controller_Data.vecAngularVelocity);
+			device.SetAcceleration(rightAcc, data.right_Controller_Data.vecAcceleration, data.right_Controller_Data.vecAngularAcceleration);
 
 			osvrDeviceTrackerSendPoseTimestamped(device.m_dev, device.m_tracker, &rightController, 3, &device.m_lastreport_time);
-			//osvrDeviceTrackerSendVelocityTimestamped(device.m_dev, device.m_tracker, &rightVel, 3, &device.m_lastreport_time);
-			//osvrDeviceTrackerSendAccelerationTimestamped(device.m_dev, device.m_tracker, &rightAcc, 3, &device.m_lastreport_time);
+			osvrDeviceTrackerSendVelocityTimestamped(device.m_dev, device.m_tracker, &rightVel, 3, &device.m_lastreport_time);
+			osvrDeviceTrackerSendAccelerationTimestamped(device.m_dev, device.m_tracker, &rightAcc, 3, &device.m_lastreport_time);
 
 			/*
 			Report Buttons
@@ -297,10 +303,6 @@ namespace {
 			osvrQuatSetZ(&acc.angularAcceleration.incrementalRotation, angularAccelerationScale * -j);
 			acc.angularAcceleration.dt = angularAcceleartionDt;
 			acc.angularAccelerationValid = true;
-		}
-
-		OSVR_ReturnCode update() {
-			return OSVR_RETURN_SUCCESS;
 		}
 
 		// Sets vibration strength in percent

--- a/com_osvr_Nolo_win.cpp
+++ b/com_osvr_Nolo_win.cpp
@@ -67,14 +67,14 @@ namespace {
 	const static int NUM_BUTTONS = 6;
 	class NoloDevice {
 	public:
-		NoloDevice(OSVR_PluginRegContext ctx,
-			char *path) {
+		NoloDevice(OSVR_PluginRegContext ctx) {
 			/// Create the initialization options
 			OSVR_DeviceInitOptions opts = osvrDeviceCreateInitOptions(ctx);
 
-			std::cout << "Nolo: opening " << path <<
-				" for " << this << std::endl;
-			m_hid = hid_open_path(path);
+			std::cout << "Starting nolo-osvr driver.\n";
+			//changeme
+			//std::cout << "Nolo: opening " << path <<
+			//	" for " << this << std::endl;
 
 			/// Indicate that we'll want 7 analog channels.
 			//osvrDeviceAnalogConfigure(opts, &m_analog, 2*3+1);
@@ -95,359 +95,221 @@ namespace {
 			m_dev.registerUpdateCallback(this);
 
 			memset(&oldreports[0][0], 0, sizeof oldreports);
+
+			NOLO::registerDisConnectCallBack(disconnectNolo, this);
+			NOLO::registerConnectSuccessCallBack(connectNolo, this);
+			NOLO::registerExpandDataNotifyCallBack(expandDataNotify, this);
+			NOLO::registerNoloDataNotifyCallBack(noloDataNotify, this);
+			NOLO::search_Nolo_Device();
 		}
 		~NoloDevice() {
 			std::cout << "Nolo: deleting " << this << std::endl;
-			hid_close(m_hid);
+			NOLO::close_Nolo_Device();
+		}
+
+		static void disconnectNolo(void* context) {
+			NoloDevice& device = *(NoloDevice*)context;
+			device.m_is_nolo_connected = false;
+			std::cout << "Nolo hardware disconnected.\n";
+		}
+
+		static void connectNolo(void* context) {
+			NoloDevice& device = *(NoloDevice*)context;
+			device.m_is_nolo_connected = true;
+			std::cout << "Nolo hardware connected.\n";
+		}
+
+		static void expandDataNotify(NOLO::ExpandMsgType msgType, void* context) {
+			NoloDevice& device = *(NoloDevice*)context;
+		}
+
+		static void noloDataNotify(NOLO::NoloData data, void* context) {
+			NoloDevice& device = *(NoloDevice*)context;
+			if (!device.m_is_nolo_connected) {
+				return;
+			}
+
+			osvrTimeValueGetNow(&device.m_lastreport_time);
+			double translationScale = 1.0f;
+
+			/*
+			Report HMD Pose
+			*/
+			OSVR_PositionState home;
+			OSVR_PoseState hmd;
+			OSVR_VelocityState hmdVel;
+			OSVR_AccelerationState hmdAcc;
+
+			device.SetPosition(home, data.hmdData.HMDInitPosition);
+			device.SetPose(hmd, data.hmdData.HMDPosition, data.hmdData.HMDRotation);
+			device.SetVelocity(hmdVel, data.hmdData.vecVelocity, data.hmdData.vecAngularVelocity);
+			device.SetAcceleration(hmdAcc, data.hmdData.vecAcceleration, data.hmdData.vecAngularAcceleration);
+
+			osvrDeviceTrackerSendPositionTimestamped(device.m_dev, device.m_tracker, &home, 0, &device.m_lastreport_time);
+			osvrDeviceTrackerSendPoseTimestamped(device.m_dev, device.m_tracker, &hmd, 1, &device.m_lastreport_time);
+			osvrDeviceTrackerSendVelocityTimestamped(device.m_dev, device.m_tracker, &hmdVel, 1, &device.m_lastreport_time);
+			osvrDeviceTrackerSendAccelerationTimestamped(device.m_dev, device.m_tracker, &hmdAcc, 1, &device.m_lastreport_time);
+
+			/*
+			Report Controller Pose
+			*/
+			OSVR_PoseState leftController;
+			OSVR_VelocityState leftVel;
+			OSVR_AccelerationState leftAcc;
+
+			OSVR_PoseState rightController;
+			OSVR_VelocityState rightVel;
+			OSVR_AccelerationState rightAcc;
+
+			device.SetPose(leftController, data.left_Controller_Data.ControllerPosition, data.left_Controller_Data.ControllerRotation);
+			device.SetVelocity(leftVel, data.left_Controller_Data.vecVelocity, data.left_Controller_Data.vecAngularVelocity);
+			device.SetAcceleration(leftAcc, data.left_Controller_Data.vecAcceleration, data.left_Controller_Data.vecAngularAcceleration);
+
+			osvrDeviceTrackerSendPoseTimestamped(device.m_dev, device.m_tracker, &leftController, 2, &device.m_lastreport_time);
+			osvrDeviceTrackerSendVelocityTimestamped(device.m_dev, device.m_tracker, &leftVel, 2, &device.m_lastreport_time);
+			osvrDeviceTrackerSendAccelerationTimestamped(device.m_dev, device.m_tracker, &leftAcc, 2, &device.m_lastreport_time);
+
+			device.SetPose(rightController, data.right_Controller_Data.ControllerPosition, data.right_Controller_Data.ControllerRotation);
+			device.SetVelocity(rightVel, data.right_Controller_Data.vecVelocity, data.right_Controller_Data.vecAngularVelocity);
+			device.SetAcceleration(rightAcc, data.right_Controller_Data.vecAcceleration, data.right_Controller_Data.vecAngularAcceleration);
+
+			osvrDeviceTrackerSendPoseTimestamped(device.m_dev, device.m_tracker, &rightController, 3, &device.m_lastreport_time);
+			osvrDeviceTrackerSendVelocityTimestamped(device.m_dev, device.m_tracker, &rightVel, 3, &device.m_lastreport_time);
+			osvrDeviceTrackerSendAccelerationTimestamped(device.m_dev, device.m_tracker, &rightAcc, 3, &device.m_lastreport_time);
+
+			/*
+			Report Buttons
+			*/
+			unsigned int leftButtons = data.left_Controller_Data.Buttons;
+			unsigned int rightButtons = data.right_Controller_Data.Buttons;
+			OSVR_ButtonState buttonValues[12];
+
+			for (unsigned int i = 0; i < 5; ++i) {
+				buttonValues[i] = leftButtons & (2 ^ i) == (2 ^ i);
+			}
+			for (unsigned int i = 6; i < 11; ++i) {
+				unsigned int j = i - 6;
+				buttonValues[i] = rightButtons & (2 ^ j) == (2 ^ j);
+			}
+			buttonValues[5] = data.left_Controller_Data.ControllerTouched;
+			buttonValues[11] = data.right_Controller_Data.ControllerTouched;
+			osvrDeviceButtonSetValuesTimestamped(device.m_dev, device.m_button, buttonValues, 12, &device.m_lastreport_time);
+
+			/*
+			Report Analog Touchpad
+			*/
+			double leftx = data.left_Controller_Data.ControllerTouchAxis.x;
+			double lefty = data.left_Controller_Data.ControllerTouchAxis.y;
+			double rightx = data.right_Controller_Data.ControllerTouchAxis.x;
+			double righty = data.right_Controller_Data.ControllerTouchAxis.y;
+			osvrDeviceAnalogSetValueTimestamped(device.m_dev, device.m_analog, leftx, 0, &device.m_lastreport_time);
+			osvrDeviceAnalogSetValueTimestamped(device.m_dev, device.m_analog, lefty, 1, &device.m_lastreport_time);
+			osvrDeviceAnalogSetValueTimestamped(device.m_dev, device.m_analog, rightx, 4, &device.m_lastreport_time);
+			osvrDeviceAnalogSetValueTimestamped(device.m_dev, device.m_analog, righty, 5, &device.m_lastreport_time);
+			/*
+			Report Status
+			*/
+			int leftBattery = (float)data.left_Controller_Data.ControllerBattery / 3.0f;
+			int rightBattery = (float)data.right_Controller_Data.ControllerBattery / 3.0f;
+			float baseBattery = (float)data.baseStationData.BaseStationPower / 3.0f;
+			osvrDeviceAnalogSetValueTimestamped(device.m_dev, device.m_analog, leftBattery, 3, &device.m_lastreport_time);
+			osvrDeviceAnalogSetValueTimestamped(device.m_dev, device.m_analog, rightBattery, 7, &device.m_lastreport_time);
+			osvrDeviceAnalogSetValueTimestamped(device.m_dev, device.m_analog, baseBattery, 8, &device.m_lastreport_time);
+		}
+
+		void SetPose(OSVR_PoseState& pose, NOLO::Vector3& pos, NOLO::Quaternion& rot) {
+			SetPosition(pose.translation, pos);
+			SetRotation(pose.rotation, rot);
+		}
+
+		void SetVelocity(OSVR_VelocityState& vel, NOLO::Vector3& linear, NOLO::Vector3& angular) {
+			SetLinearVelocity(vel, linear);
+			SetAngularVelocity(vel, angular);
+		}
+
+		void SetAcceleration(OSVR_AccelerationState& acc, NOLO::Vector3& linear, NOLO::Vector3& angular) {
+			SetLinearAcceleration(acc, linear);
+			SetAngularAcceleration(acc, angular);
+		}
+
+		void SetPosition(OSVR_PositionState& pos, NOLO::Vector3& data) {
+			double translationScale = 1.0f;
+			osvrVec3SetX(&pos, translationScale * data.x);
+			osvrVec3SetY(&pos, translationScale * data.y);
+			osvrVec3SetZ(&pos, translationScale * data.z);
+		}
+
+		void SetRotation(OSVR_Quaternion& quat, NOLO::Quaternion& data) {
+			osvrQuatSetW(&quat, data.w);
+			osvrQuatSetX(&quat, data.x);
+			osvrQuatSetY(&quat, data.y);
+			osvrQuatSetZ(&quat, data.z);
+		}
+
+		void SetLinearVelocity(OSVR_VelocityState& vel, NOLO::Vector3& data) {
+			double velocityScale = 1.0f;
+			osvrVec3SetX(&vel.linearVelocity, velocityScale * data.x);
+			osvrVec3SetY(&vel.linearVelocity, velocityScale * data.y);
+			osvrVec3SetZ(&vel.linearVelocity, velocityScale * data.z);
+			vel.linearVelocityValid = true;
+		}
+
+		void SetAngularVelocity(OSVR_VelocityState& vel, NOLO::Vector3& data) {
+			double angularVelocityScale = 1.0f;
+			double angularVelocityDt = 1.0f;
+			double i = data.x;
+			double j = data.y;
+			double k = data.z;
+			double mag = sqrt(i*i + j*j + k*k);
+			osvrQuatSetW(&vel.angularVelocity.incrementalRotation, angularVelocityScale * mag);
+			osvrQuatSetX(&vel.angularVelocity.incrementalRotation, angularVelocityScale * i);
+			osvrQuatSetY(&vel.angularVelocity.incrementalRotation, angularVelocityScale * k);
+			osvrQuatSetZ(&vel.angularVelocity.incrementalRotation, angularVelocityScale * -j);
+			vel.angularVelocity.dt = angularVelocityDt;
+			vel.angularVelocityValid = true;
+		}
+
+		void SetLinearAcceleration(OSVR_AccelerationState& acc, NOLO::Vector3& data) {
+			double accelerationScale = 1.0f;
+			osvrVec3SetX(&acc.linearAcceleration, accelerationScale * data.x);
+			osvrVec3SetY(&acc.linearAcceleration, accelerationScale * data.y);
+			osvrVec3SetZ(&acc.linearAcceleration, accelerationScale * data.z);
+			acc.linearAccelerationValid = true;
+		}
+
+		void SetAngularAcceleration(OSVR_AccelerationState& acc, NOLO::Vector3& data) {
+			double angularAccelerationScale = 1.0f;
+			double angularAcceleartionDt = 1.0f;
+			double i = data.x;
+			double j = data.y;
+			double k = data.z;
+			double mag = sqrt(i*i + j*j + k*k);
+			osvrQuatSetW(&acc.angularAcceleration.incrementalRotation, angularAccelerationScale * mag);
+			osvrQuatSetX(&acc.angularAcceleration.incrementalRotation, angularAccelerationScale * i);
+			osvrQuatSetY(&acc.angularAcceleration.incrementalRotation, angularAccelerationScale * k);
+			osvrQuatSetZ(&acc.angularAcceleration.incrementalRotation, angularAccelerationScale * -j);
+			acc.angularAcceleration.dt = angularAcceleartionDt;
+			acc.angularAccelerationValid = true;
 		}
 
 		OSVR_ReturnCode update() {
-			unsigned char buf[64];
-			const int cryptwords = (64 - 4) / 4, cryptoffset = 1;
-			static const uint32_t key[4] =
-			{ 0x875bcc51, 0xa7637a66, 0x50960967, 0xf8536c51 };
-			uint32_t cryptpart[cryptwords];
-			int i;
-
-			// TODO: timestamp frame received?
-			if (!m_hid)
-				OSVR_RETURN_FAILURE;
-			//std::cout << "Reading HID data from " << m_hid << std::endl;
-			if (hid_read(m_hid, buf, sizeof buf) != sizeof buf)
-				return OSVR_RETURN_FAILURE;
-			osvrTimeValueGetNow(&m_lastreport_time);
-
-			// Check for duplicate reports before decrypting
-			switch (buf[0]) {
-			case 0xa5:
-			case 0xa6:
-				if (memcmp(oldreports[buf[0] - 0xa5], buf, sizeof buf))
-					memcpy(oldreports[buf[0] - 0xa5], buf, sizeof buf);
-				else
-					return OSVR_RETURN_SUCCESS;	// Duplicate report
-				break;
-			default:
-				return OSVR_RETURN_SUCCESS; // Unknown report
-			}
-			//std::cout << "R ";
-			//hexdump(buf, sizeof buf);
-			// Decrypt encrypted portion
-			for (i = 0; i < cryptwords; i++) {
-				cryptpart[i] =
-					((uint32_t)buf[cryptoffset + 4 * i]) << 0 |
-					((uint32_t)buf[cryptoffset + 4 * i + 1]) << 8 |
-					((uint32_t)buf[cryptoffset + 4 * i + 2]) << 16 |
-					((uint32_t)buf[cryptoffset + 4 * i + 3]) << 24;
-			}
-			btea_decrypt(cryptpart, cryptwords, 1, key);
-			for (i = 0; i < cryptwords; i++) {
-				buf[cryptoffset + 4 * i] = cryptpart[i] >> 0;
-				buf[cryptoffset + 4 * i + 1] = cryptpart[i] >> 8;
-				buf[cryptoffset + 4 * i + 2] = cryptpart[i] >> 16;
-				buf[cryptoffset + 4 * i + 3] = cryptpart[i] >> 24;
-			}
-			//std::cout << "D ";
-			//hexdump(buf, sizeof buf);
-
-			switch (buf[0]) {
-			case 0xa5:  // controllers frame
-				decodeControllerCV1(0, buf + 1);
-				decodeControllerCV1(1, buf + 64 - controllerLength);
-				break;
-			case 0xa6:
-				decodeHeadsetMarkerCV1(buf + 0x15);
-				decodeBaseStationCV1(buf + 0x36);
-				break;
-			}
 			return OSVR_RETURN_SUCCESS;
 		}
 
 		// Sets vibration strength in percent
 		int setVibration(unsigned char left,
 			unsigned char right) {
-			unsigned char data[4] = { 0xaa, 0x66, left, right };
-			return hid_write(m_hid, data, sizeof data);
+			int left_percentage = floor(double(left) / 255.0 * 100.0);
+			int right_percentage = floor(double(right) / 255.0 * 100.0);
 		}
 
 	private:
 		unsigned char oldreports[2][64];
-		void decodePosition(const unsigned char *data,
-			OSVR_PositionState *pos) {
-			const double scale = 0.0001;
-			osvrVec3SetX(pos, scale * (int16_t)(data[0] << 8 | data[1]));
-			osvrVec3SetY(pos, scale * (int16_t)(data[2] << 8 | data[3]));
-			osvrVec3SetZ(pos, scale *          (data[4] << 8 | data[5]));
-		}
-		void decodeOrientation(const unsigned char *data,
-			OSVR_OrientationState *quat) {
-			double w, i, j, k, scale;
-			// CV1 order
-			w = (int16_t)(data[0] << 8 | data[1]);
-			i = (int16_t)(data[2] << 8 | data[3]);
-			j = (int16_t)(data[4] << 8 | data[5]);
-			k = (int16_t)(data[6] << 8 | data[7]);
-			// Normalize (unknown if scale is constant)
-			//scale = 1.0/sqrt(i*i+j*j+k*k+w*w);
-			// Turns out it is fixed point. But the android driver author
-			// either didn't know, or didn't trust it.
-			// Unknown if normalizing it helps OSVR!
-			scale = 1.0 / 16384;
-			//std::cout << "Scale: " << scale << std::endl;
-			w *= scale;
-			i *= scale;
-			j *= scale;
-			k *= scale;
-			// Reorder
-			osvrQuatSetW(quat, w);
-			osvrQuatSetX(quat, i);
-			osvrQuatSetY(quat, k);
-			osvrQuatSetZ(quat, -j);
-		}
-		void decodeVelocity(const unsigned char *data,
-			OSVR_LinearVelocityState *lin_vel) {
-			const double scale = 0.0001;
-			osvrVec3SetX(lin_vel, scale * (int16_t)(data[0] << 8 | data[1]));
-			osvrVec3SetY(lin_vel, scale * (int16_t)(data[2] << 8 | data[3]));
-			osvrVec3SetZ(lin_vel, scale *          (data[4] << 8 | data[5]));
-		}
-		void decodeAcceleration(const unsigned char *data,
-			OSVR_LinearAccelerationState *lin_accel) {
-			const double scale = 0.0001;
-			osvrVec3SetX(lin_accel, scale * (int16_t)(data[0] << 8 | data[1]));
-			osvrVec3SetY(lin_accel, scale * (int16_t)(data[2] << 8 | data[3]));
-			osvrVec3SetZ(lin_accel, scale *          (data[4] << 8 | data[5]));
-		}
-		void decodeAngularVelocity(const unsigned char *data,
-			OSVR_AngularVelocityState *ang_vel) {
-			double i, j, k;
-			i = (int16_t)(data[0] << 8 | data[1]);
-			j = (int16_t)(data[2] << 8 | data[3]);
-			k = (int16_t)(data[4] << 8 | data[5]);
-			osvrQuatSetX(&ang_vel->incrementalRotation, i);
-			osvrQuatSetY(&ang_vel->incrementalRotation, k);
-			osvrQuatSetZ(&ang_vel->incrementalRotation, -j);
-			// magnitude is rotation in rad/s
-			osvrQuatSetW(&ang_vel->incrementalRotation, sqrt(i*i + j*j + k*k));
-			ang_vel->dt = 1.0;
-		}
-		void decodeAngularAcceleration(const unsigned char *data,
-			OSVR_AngularAccelerationState *ang_accel) {
-			double i, j, k;
-			i = (int16_t)(data[0] << 8 | data[1]);
-			j = (int16_t)(data[2] << 8 | data[3]);
-			k = (int16_t)(data[4] << 8 | data[5]);
-			osvrQuatSetX(&ang_accel->incrementalRotation, i);
-			osvrQuatSetY(&ang_accel->incrementalRotation, k);
-			osvrQuatSetZ(&ang_accel->incrementalRotation, -j);
-			// magnitude is rotation in rad/s*2
-			osvrQuatSetW(&ang_accel->incrementalRotation, sqrt(i*i + j*j + k*k));
-			ang_accel->dt = 1.0;
-		}
-
-		void decodeControllerCV1(int idx, unsigned char *data) {
-			enum ControllerOffsets {
-				hwversion = 0,	// guessed!
-				fwversion = 1,
-				position = 3,
-				orientation = 3 + 3 * 2,
-				ofsbuttons = 3 + 3 * 2 + 4 * 2,
-				touchid = 3 + 3 * 2 + 4 * 2 + 1,
-				touchx = 3 + 3 * 2 + 4 * 2 + 2,
-				touchy = 3 + 3 * 2 + 4 * 2 + 3,
-				battery = 3 + 3 * 2 + 4 * 2 + 4,
-				velocity = 3 + 3 * 2 + 4 * 2 + 5,  // Added with 2.0/2.1 firmware
-				accel = 3 + 3 * 2 + 4 * 2 + 5 + 3 * 2,
-				ang_velocity = 3 + 3 * 2 + 4 * 2 + 5 + 6 * 2,
-				ang_accel = 3 + 3 * 2 + 4 * 2 + 5 + 9 * 2,
-				state = 3 + 3 * 2 + 4 * 2 + 5 + 12 * 2
-			};
-			OSVR_PoseState pose;
-			uint8_t buttons, bit;
-			int trigger_pressed = 0;
-
-			if (data[hwversion] != 2 || data[fwversion] != 1) {
-				// Unknown version
-				/* Happens when controllers aren't on.
-				std::cout << "Nolo: Unknown controller " << idx
-				<< " version " << (int)data[0] << " " << (int)data[1]
-				<< std::endl;
-				*/
-				return;
-			}
-
-			decodePosition(data + position, &pose.translation);
-			decodeOrientation(data + orientation, &pose.rotation);
-
-			osvrDeviceTrackerSendPoseTimestamped(m_dev, m_tracker, &pose, 2 + idx, &m_lastreport_time);
-
-			buttons = data[ofsbuttons];
-			// TODO: report buttons for both controllers in one call?
-			for (bit = 0; bit < NUM_BUTTONS; bit++){
-				osvrDeviceButtonSetValueTimestamped(m_dev, m_button,
-					(buttons & 1 << bit ? OSVR_BUTTON_PRESSED
-					: OSVR_BUTTON_NOT_PRESSED), idx * 6 + bit,
-					&m_lastreport_time);
-				if (bit == 1){
-					if (buttons & 1 << bit){
-						trigger_pressed = 1;
-					}
-					else{
-						trigger_pressed = 0;
-					}
-				}
-			}
-			// next byte is touch ID bitmask (identical to buttons bit 5)
-
-			// Touch X and Y coordinates
-			// //assumes 0 to 255
-			// normalize from -1 to 1
-			// z = 2*[x - min / (max - min) - 1]
-			// z = 2*(x - 0 / (255 - 0) - 1]
-			// z = 2*(x/255) -1
-			// normalize 0 to 1
-			// x/255
-			double axis_value;
-			if (data[touchid]) {  // Only report touch if there is one
-				axis_value = 2 * data[touchx] / 255.0 - 1;
-				// Attempt to calibrate, assuming trackpads are only good out to about 60%
-				axis_value *= 1.6667;
-				axis_value = std::fmax(-1, std::fmin(axis_value, 1));
-				// invert axis
-				axis_value *= -1;
-				// Fix edge case by guessing appropriate value (necessary because touchid apparently doesn't always work)
-				if (data[touchx] == 0) {
-					axis_value = m_last_axis[idx*NUM_AXIS + 0] < 0 ? -1 : 1;
-				}
-				m_last_axis[idx*NUM_AXIS + 0] = axis_value;
-				osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, axis_value, idx*NUM_AXIS + 0, &m_lastreport_time);
-
-				axis_value = 2 * ((int)data[touchy]) / 255.0 - 1;
-				// Attempt to calibrate, assuming trackpads are only good out to about 60%
-				axis_value *= 1.6667;
-				axis_value = std::fmax(-1, std::fmin(axis_value, 1));
-				// invert axis
-				axis_value *= -1;
-				// Fix edge case by guessing appropriate value (necessary because touchid apparently doesn't always work)
-				if (data[touchy] == 0) {
-					axis_value = m_last_axis[idx*NUM_AXIS + 1] < 0 ? -1 : 1;
-				}
-				m_last_axis[idx*NUM_AXIS + 1] = axis_value;
-				osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, axis_value, idx*NUM_AXIS + 1, &m_lastreport_time);
-			}
-			else { // Otherwise, report a centered value
-				axis_value = 0;
-				osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, axis_value, idx*NUM_AXIS + 0, &m_lastreport_time);
-				osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, axis_value, idx*NUM_AXIS + 1, &m_lastreport_time);
-			}
-			// trigger (emulated analog axis)
-			osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, trigger_pressed, idx*NUM_AXIS + 2, &m_lastreport_time);
-			// battery level
-			axis_value = data[battery] / 255.0;
-			osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, axis_value, idx*NUM_AXIS + 3, &m_lastreport_time);
-
-			// velocity and acceleration data
-			OSVR_LinearVelocityState lin_vel_state;
-			OSVR_LinearAccelerationState lin_accel_state;
-			decodeVelocity(data + velocity, &lin_vel_state);
-			decodeAcceleration(data + accel, &lin_accel_state);
-
-			osvrDeviceTrackerSendLinearVelocityTimestamped(m_dev, m_tracker, &lin_vel_state, 2 + idx, &m_lastreport_time);
-			osvrDeviceTrackerSendLinearAccelerationTimestamped(m_dev, m_tracker, &lin_accel_state, 2 + idx, &m_lastreport_time);
-
-			OSVR_AngularVelocityState ang_vel_state;
-			OSVR_AngularAccelerationState ang_accel_state;
-			decodeAngularVelocity(data + ang_velocity, &ang_vel_state);
-			decodeAngularAcceleration(data + ang_accel, &ang_accel_state);
-
-			osvrDeviceTrackerSendAngularVelocityTimestamped(m_dev, m_tracker, &ang_vel_state, 2 + idx, &m_lastreport_time);
-			osvrDeviceTrackerSendAngularAccelerationTimestamped(m_dev, m_tracker, &ang_accel_state, 2 + idx, &m_lastreport_time);
-
-			// should we be using the "state" information for anything? 
-
-		}
-		void decodeHeadsetMarkerCV1(unsigned char *data) {
-			enum MarkerOffsets {
-				hwversion = 0,	// guessed!
-				fwversion = 1,
-				position = 3,
-				homeposition = 3 + 3 * 2,
-				orientation = 3 + 2 * 3 * 2 + 1,       // why the +1 offset here? (firmware dependent?)
-				velocity = 3 + 2 * 3 * 2 + 1 + 4 * 2,  // Added with 2.0/2.1 firmware
-				accel = 3 + 2 * 3 * 2 + 1 + 7 * 2,
-				ang_velocity = 3 + 2 * 3 * 2 + 1 + 10 * 2,
-				ang_accel = 3 + 2 * 3 * 2 + 1 + 13 * 2,
-				state = 3 + 2 * 3 * 2 + 1 + 16 * 2
-			};
-			if (data[hwversion] != 2 || data[fwversion] != 1) {
-				/* Happens with corrupt packages (mixed with controller data)
-				std::cout << "Nolo: Unknown headset marker"
-				<< " version " << (int)data[0] << " " << (int)data[1]
-				<< std::endl;
-				*/
-				// Unknown version
-				return;
-			}
-
-			OSVR_PositionState home;
-			OSVR_PoseState hmd;
-
-			decodePosition(data + position, &hmd.translation);
-			decodePosition(data + homeposition, &home);
-			decodeOrientation(data + orientation, &hmd.rotation);
-
-			// Send button press if home position changed
-			if (home.data[0] != m_last_home.data[0]) { // An exact comparison on the x value is probably sufficient, if not necessarily proper
-				osvrDeviceButtonSetValueTimestamped(m_dev, m_button, OSVR_BUTTON_PRESSED, 12, &m_lastreport_time);
-				m_last_home.data[0] = home.data[0];
-			}
-			else {
-				osvrDeviceButtonSetValueTimestamped(m_dev, m_button, OSVR_BUTTON_NOT_PRESSED, 12, &m_lastreport_time);
-			}
-
-			// Tracker viewer kept using the home for head.
-			// Something wrong with how they handle the descriptors. 
-			osvrDeviceTrackerSendPositionTimestamped(m_dev, m_tracker, &home, 0,
-				&m_lastreport_time);
-
-			osvrDeviceTrackerSendPoseTimestamped(m_dev, m_tracker, &hmd, 1,
-				&m_lastreport_time);
-
-			// velocity and acceleration data
-			OSVR_LinearVelocityState lin_vel_state;
-			OSVR_LinearAccelerationState lin_accel_state;
-			decodeVelocity(data + velocity, &lin_vel_state);
-			decodeAcceleration(data + accel, &lin_accel_state);
-
-			osvrDeviceTrackerSendLinearVelocityTimestamped(m_dev, m_tracker, &lin_vel_state, 1, &m_lastreport_time);
-			osvrDeviceTrackerSendLinearAccelerationTimestamped(m_dev, m_tracker, &lin_accel_state, 1, &m_lastreport_time);
-
-			OSVR_AngularVelocityState ang_vel_state;
-			OSVR_AngularAccelerationState ang_accel_state;
-			decodeAngularVelocity(data + ang_velocity, &ang_vel_state);
-			decodeAngularAcceleration(data + ang_accel, &ang_accel_state);
-
-			osvrDeviceTrackerSendAngularVelocityTimestamped(m_dev, m_tracker, &ang_vel_state, 1, &m_lastreport_time);
-			osvrDeviceTrackerSendAngularAccelerationTimestamped(m_dev, m_tracker, &ang_accel_state, 1, &m_lastreport_time);
-
-		}
-		void decodeBaseStationCV1(unsigned char *data) {
-			enum MarkerOffsets {
-				hwversion = 0,	// guessed!
-				fwversion = 1,
-				position = 2,        // This is ONLY for the 2.0/2.1 firmware!(looks like things changed)
-				battery = 2 + 3 * 2
-			};
-			if (data[hwversion] != 2 || data[fwversion] != 1)
-				// Unknown version
-				return;
-
-			osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, data[battery], 2 * NUM_AXIS,
-				&m_lastreport_time);
-		}
-
 		static const int controllerLength = 3 + (3 + 4) * 2 + 2 + 2 + 1;
 		osvr::pluginkit::DeviceToken m_dev;
-		hid_device* m_hid;
+		//changeme
+		//hid_device* m_hid;
+		bool m_is_nolo_connected;
 		OSVR_AnalogDeviceInterface m_analog;
 		OSVR_ButtonDeviceInterface m_button;
 		OSVR_TrackerDeviceInterface m_tracker;
@@ -465,23 +327,10 @@ namespace {
 			if (m_found)
 				return OSVR_RETURN_SUCCESS;
 
-			struct hid_device_info *hid_devices, *cur_dev;
-			hid_devices = hid_enumerate(0x0483, 0x5750);
-			if (!hid_devices)
-				return OSVR_RETURN_FAILURE;
+			osvr::pluginkit::registerObjectForDeletion
+				(ctx, new NoloDevice(ctx));
+			m_found = true;
 
-			for (cur_dev = hid_devices; cur_dev; cur_dev = cur_dev->next) {
-				if (wcscmp(cur_dev->manufacturer_string, L"LYRobotix") == 0 &&
-					wcscmp(cur_dev->product_string, L"NOLO") == 0) {
-					/// TODO: Distinguish Headset Marker from other parts?
-					/// Create our device object
-					osvr::pluginkit::registerObjectForDeletion
-						(ctx, new NoloDevice(ctx, cur_dev->path));
-					m_found = true;
-				}
-			}
-
-			hid_free_enumeration(hid_devices);
 			return OSVR_RETURN_SUCCESS;
 		}
 
@@ -493,7 +342,6 @@ namespace {
 } // namespace
 
 OSVR_PLUGIN(com_osvr_Nolo) {
-	hid_init();
 	osvr::pluginkit::PluginContext context(ctx);
 
 	/// Register a detection callback function object.

--- a/com_osvr_Nolo_win.cpp
+++ b/com_osvr_Nolo_win.cpp
@@ -97,9 +97,15 @@ namespace {
 			NOLO::registerDisConnectCallBack(disconnectNolo, this);
 			NOLO::registerConnectSuccessCallBack(connectNolo, this);
 			NOLO::registerExpandDataNotifyCallBack(expandDataNotify, this);
+
+			// Enable this below for ceiling mode
+			//std::cout << "Nolo: Set CeilingMode" << std::endl; 
+			//NOLO::set_Nolo_PlayMode(NOLO::CeilingMode);
+
 			// Switch to polling structure to avoid strange SteamVR bug.
 			//NOLO::registerNoloDataNotifyCallBack(noloDataNotify, this);
 			NOLO::search_Nolo_Device();
+
 		}
 		~NoloDevice() {
 			std::cout << "Nolo: deleting " << this << std::endl;
@@ -198,11 +204,11 @@ namespace {
 			OSVR_ButtonState buttonValues[12];
 
 			for (unsigned int i = 0; i < 5; ++i) {
-				buttonValues[i] = leftButtons & (2 ^ i) == (2 ^ i);
+				buttonValues[i] = ((leftButtons & (2 ^ i)) == (2 ^ i)) ? OSVR_BUTTON_PRESSED : OSVR_BUTTON_NOT_PRESSED;
 			}
 			for (unsigned int i = 6; i < 11; ++i) {
 				unsigned int j = i - 6;
-				buttonValues[i] = rightButtons & (2 ^ j) == (2 ^ j);
+				buttonValues[i] = ((rightButtons & (2 ^ j)) == (2 ^ j)) ? OSVR_BUTTON_PRESSED : OSVR_BUTTON_NOT_PRESSED;
 			}
 			buttonValues[5] = data.left_Controller_Data.ControllerTouched;
 			buttonValues[11] = data.right_Controller_Data.ControllerTouched;
@@ -222,8 +228,8 @@ namespace {
 			/*
 			Report Status
 			*/
-			int leftBattery = (float)data.left_Controller_Data.ControllerBattery / 3.0f;
-			int rightBattery = (float)data.right_Controller_Data.ControllerBattery / 3.0f;
+			float leftBattery = (float)data.left_Controller_Data.ControllerBattery / 3.0f;
+			float rightBattery = (float)data.right_Controller_Data.ControllerBattery / 3.0f;
 			float baseBattery = (float)data.baseStationData.BaseStationPower / 3.0f;
 			osvrDeviceAnalogSetValueTimestamped(device.m_dev, device.m_analog, leftBattery, 3, &device.m_lastreport_time);
 			osvrDeviceAnalogSetValueTimestamped(device.m_dev, device.m_analog, rightBattery, 7, &device.m_lastreport_time);
@@ -308,8 +314,8 @@ namespace {
 		// Sets vibration strength in percent
 		int setVibration(unsigned char left,
 			unsigned char right) {
-			int left_percentage = floor(double(left) / 255.0 * 100.0);
-			int right_percentage = floor(double(right) / 255.0 * 100.0);
+			int left_percentage = (int)(floor(double(left) / 255.0 * 100.0));
+			int right_percentage = (int)(floor(double(right) / 255.0 * 100.0));
 		}
 
 	private:

--- a/com_osvr_Nolo_win.cpp
+++ b/com_osvr_Nolo_win.cpp
@@ -1,0 +1,503 @@
+/** @file
+@brief OSVR plugin for LYRobotix Nolo trackers
+
+@date 2018
+
+@author
+Nanospork
+<http://www.nanospork.com>
+*/
+
+// Copyright 2014 Sensics, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Internal Includes
+#include <osvr/PluginKit/PluginKit.h>
+#include <osvr/PluginKit/AnalogInterfaceC.h>
+#include <osvr/PluginKit/ButtonInterfaceC.h>
+#include <osvr/PluginKit/TrackerInterfaceC.h>
+
+// Generated JSON header file
+#include "com_osvr_Nolo_json.h"
+
+// Library/third-party includes
+#include <nolo_api.h>
+
+// Standard includes
+#include <iostream>
+#include <wchar.h>
+#include <string.h>
+
+// Anonymous namespace to avoid symbol collision
+namespace {
+
+	// btea_decrypt function
+#include "btea.c"
+
+#if 0
+	void hexdump(unsigned char *data, int len) {
+		char fill = std::cout.fill();
+		std::streamsize w = std::cout.width();
+		std::ios_base::fmtflags f = std::cout.flags();
+		for (int i = 0; i<len; i++) {
+			std::cout << std::setw(2) << std::setfill('0')
+				<< std::hex << (int)data[i];
+			if (i % 8 == 7)
+				std::cout << " ";
+		}
+		std::cout << std::endl;
+		std::cout.fill(fill);
+		std::cout.width(w);
+		std::cout.flags(f);
+	};
+#endif
+
+	const static int NUM_AXIS = 4;
+	const static int NUM_BUTTONS = 6;
+	class NoloDevice {
+	public:
+		NoloDevice(OSVR_PluginRegContext ctx,
+			char *path) {
+			/// Create the initialization options
+			OSVR_DeviceInitOptions opts = osvrDeviceCreateInitOptions(ctx);
+
+			std::cout << "Nolo: opening " << path <<
+				" for " << this << std::endl;
+			m_hid = hid_open_path(path);
+
+			/// Indicate that we'll want 7 analog channels.
+			//osvrDeviceAnalogConfigure(opts, &m_analog, 2*3+1);
+			// update this to 9 analog channels to include the trigger
+			osvrDeviceAnalogConfigure(opts, &m_analog, NUM_AXIS * 2 + 1);
+			/// And 6 buttons per controller
+			osvrDeviceButtonConfigure(opts, &m_button, 2 * NUM_BUTTONS);
+			/// And tracker capability
+			osvrDeviceTrackerConfigure(opts, &m_tracker);
+
+			/// Create the device token with the options
+			m_dev.initAsync(ctx, "LYRobotix Nolo", opts);
+
+			/// Send JSON descriptor
+			m_dev.sendJsonDescriptor(com_osvr_Nolo_json);
+
+			/// Register update callback
+			m_dev.registerUpdateCallback(this);
+
+			memset(&oldreports[0][0], 0, sizeof oldreports);
+		}
+		~NoloDevice() {
+			std::cout << "Nolo: deleting " << this << std::endl;
+			hid_close(m_hid);
+		}
+
+		OSVR_ReturnCode update() {
+			unsigned char buf[64];
+			const int cryptwords = (64 - 4) / 4, cryptoffset = 1;
+			static const uint32_t key[4] =
+			{ 0x875bcc51, 0xa7637a66, 0x50960967, 0xf8536c51 };
+			uint32_t cryptpart[cryptwords];
+			int i;
+
+			// TODO: timestamp frame received?
+			if (!m_hid)
+				OSVR_RETURN_FAILURE;
+			//std::cout << "Reading HID data from " << m_hid << std::endl;
+			if (hid_read(m_hid, buf, sizeof buf) != sizeof buf)
+				return OSVR_RETURN_FAILURE;
+			osvrTimeValueGetNow(&m_lastreport_time);
+
+			// Check for duplicate reports before decrypting
+			switch (buf[0]) {
+			case 0xa5:
+			case 0xa6:
+				if (memcmp(oldreports[buf[0] - 0xa5], buf, sizeof buf))
+					memcpy(oldreports[buf[0] - 0xa5], buf, sizeof buf);
+				else
+					return OSVR_RETURN_SUCCESS;	// Duplicate report
+				break;
+			default:
+				return OSVR_RETURN_SUCCESS; // Unknown report
+			}
+			//std::cout << "R ";
+			//hexdump(buf, sizeof buf);
+			// Decrypt encrypted portion
+			for (i = 0; i < cryptwords; i++) {
+				cryptpart[i] =
+					((uint32_t)buf[cryptoffset + 4 * i]) << 0 |
+					((uint32_t)buf[cryptoffset + 4 * i + 1]) << 8 |
+					((uint32_t)buf[cryptoffset + 4 * i + 2]) << 16 |
+					((uint32_t)buf[cryptoffset + 4 * i + 3]) << 24;
+			}
+			btea_decrypt(cryptpart, cryptwords, 1, key);
+			for (i = 0; i < cryptwords; i++) {
+				buf[cryptoffset + 4 * i] = cryptpart[i] >> 0;
+				buf[cryptoffset + 4 * i + 1] = cryptpart[i] >> 8;
+				buf[cryptoffset + 4 * i + 2] = cryptpart[i] >> 16;
+				buf[cryptoffset + 4 * i + 3] = cryptpart[i] >> 24;
+			}
+			//std::cout << "D ";
+			//hexdump(buf, sizeof buf);
+
+			switch (buf[0]) {
+			case 0xa5:  // controllers frame
+				decodeControllerCV1(0, buf + 1);
+				decodeControllerCV1(1, buf + 64 - controllerLength);
+				break;
+			case 0xa6:
+				decodeHeadsetMarkerCV1(buf + 0x15);
+				decodeBaseStationCV1(buf + 0x36);
+				break;
+			}
+			return OSVR_RETURN_SUCCESS;
+		}
+
+		// Sets vibration strength in percent
+		int setVibration(unsigned char left,
+			unsigned char right) {
+			unsigned char data[4] = { 0xaa, 0x66, left, right };
+			return hid_write(m_hid, data, sizeof data);
+		}
+
+	private:
+		unsigned char oldreports[2][64];
+		void decodePosition(const unsigned char *data,
+			OSVR_PositionState *pos) {
+			const double scale = 0.0001;
+			osvrVec3SetX(pos, scale * (int16_t)(data[0] << 8 | data[1]));
+			osvrVec3SetY(pos, scale * (int16_t)(data[2] << 8 | data[3]));
+			osvrVec3SetZ(pos, scale *          (data[4] << 8 | data[5]));
+		}
+		void decodeOrientation(const unsigned char *data,
+			OSVR_OrientationState *quat) {
+			double w, i, j, k, scale;
+			// CV1 order
+			w = (int16_t)(data[0] << 8 | data[1]);
+			i = (int16_t)(data[2] << 8 | data[3]);
+			j = (int16_t)(data[4] << 8 | data[5]);
+			k = (int16_t)(data[6] << 8 | data[7]);
+			// Normalize (unknown if scale is constant)
+			//scale = 1.0/sqrt(i*i+j*j+k*k+w*w);
+			// Turns out it is fixed point. But the android driver author
+			// either didn't know, or didn't trust it.
+			// Unknown if normalizing it helps OSVR!
+			scale = 1.0 / 16384;
+			//std::cout << "Scale: " << scale << std::endl;
+			w *= scale;
+			i *= scale;
+			j *= scale;
+			k *= scale;
+			// Reorder
+			osvrQuatSetW(quat, w);
+			osvrQuatSetX(quat, i);
+			osvrQuatSetY(quat, k);
+			osvrQuatSetZ(quat, -j);
+		}
+		void decodeVelocity(const unsigned char *data,
+			OSVR_LinearVelocityState *lin_vel) {
+			const double scale = 0.0001;
+			osvrVec3SetX(lin_vel, scale * (int16_t)(data[0] << 8 | data[1]));
+			osvrVec3SetY(lin_vel, scale * (int16_t)(data[2] << 8 | data[3]));
+			osvrVec3SetZ(lin_vel, scale *          (data[4] << 8 | data[5]));
+		}
+		void decodeAcceleration(const unsigned char *data,
+			OSVR_LinearAccelerationState *lin_accel) {
+			const double scale = 0.0001;
+			osvrVec3SetX(lin_accel, scale * (int16_t)(data[0] << 8 | data[1]));
+			osvrVec3SetY(lin_accel, scale * (int16_t)(data[2] << 8 | data[3]));
+			osvrVec3SetZ(lin_accel, scale *          (data[4] << 8 | data[5]));
+		}
+		void decodeAngularVelocity(const unsigned char *data,
+			OSVR_AngularVelocityState *ang_vel) {
+			double i, j, k;
+			i = (int16_t)(data[0] << 8 | data[1]);
+			j = (int16_t)(data[2] << 8 | data[3]);
+			k = (int16_t)(data[4] << 8 | data[5]);
+			osvrQuatSetX(&ang_vel->incrementalRotation, i);
+			osvrQuatSetY(&ang_vel->incrementalRotation, k);
+			osvrQuatSetZ(&ang_vel->incrementalRotation, -j);
+			// magnitude is rotation in rad/s
+			osvrQuatSetW(&ang_vel->incrementalRotation, sqrt(i*i + j*j + k*k));
+			ang_vel->dt = 1.0;
+		}
+		void decodeAngularAcceleration(const unsigned char *data,
+			OSVR_AngularAccelerationState *ang_accel) {
+			double i, j, k;
+			i = (int16_t)(data[0] << 8 | data[1]);
+			j = (int16_t)(data[2] << 8 | data[3]);
+			k = (int16_t)(data[4] << 8 | data[5]);
+			osvrQuatSetX(&ang_accel->incrementalRotation, i);
+			osvrQuatSetY(&ang_accel->incrementalRotation, k);
+			osvrQuatSetZ(&ang_accel->incrementalRotation, -j);
+			// magnitude is rotation in rad/s*2
+			osvrQuatSetW(&ang_accel->incrementalRotation, sqrt(i*i + j*j + k*k));
+			ang_accel->dt = 1.0;
+		}
+
+		void decodeControllerCV1(int idx, unsigned char *data) {
+			enum ControllerOffsets {
+				hwversion = 0,	// guessed!
+				fwversion = 1,
+				position = 3,
+				orientation = 3 + 3 * 2,
+				ofsbuttons = 3 + 3 * 2 + 4 * 2,
+				touchid = 3 + 3 * 2 + 4 * 2 + 1,
+				touchx = 3 + 3 * 2 + 4 * 2 + 2,
+				touchy = 3 + 3 * 2 + 4 * 2 + 3,
+				battery = 3 + 3 * 2 + 4 * 2 + 4,
+				velocity = 3 + 3 * 2 + 4 * 2 + 5,  // Added with 2.0/2.1 firmware
+				accel = 3 + 3 * 2 + 4 * 2 + 5 + 3 * 2,
+				ang_velocity = 3 + 3 * 2 + 4 * 2 + 5 + 6 * 2,
+				ang_accel = 3 + 3 * 2 + 4 * 2 + 5 + 9 * 2,
+				state = 3 + 3 * 2 + 4 * 2 + 5 + 12 * 2
+			};
+			OSVR_PoseState pose;
+			uint8_t buttons, bit;
+			int trigger_pressed = 0;
+
+			if (data[hwversion] != 2 || data[fwversion] != 1) {
+				// Unknown version
+				/* Happens when controllers aren't on.
+				std::cout << "Nolo: Unknown controller " << idx
+				<< " version " << (int)data[0] << " " << (int)data[1]
+				<< std::endl;
+				*/
+				return;
+			}
+
+			decodePosition(data + position, &pose.translation);
+			decodeOrientation(data + orientation, &pose.rotation);
+
+			osvrDeviceTrackerSendPoseTimestamped(m_dev, m_tracker, &pose, 2 + idx, &m_lastreport_time);
+
+			buttons = data[ofsbuttons];
+			// TODO: report buttons for both controllers in one call?
+			for (bit = 0; bit < NUM_BUTTONS; bit++){
+				osvrDeviceButtonSetValueTimestamped(m_dev, m_button,
+					(buttons & 1 << bit ? OSVR_BUTTON_PRESSED
+					: OSVR_BUTTON_NOT_PRESSED), idx * 6 + bit,
+					&m_lastreport_time);
+				if (bit == 1){
+					if (buttons & 1 << bit){
+						trigger_pressed = 1;
+					}
+					else{
+						trigger_pressed = 0;
+					}
+				}
+			}
+			// next byte is touch ID bitmask (identical to buttons bit 5)
+
+			// Touch X and Y coordinates
+			// //assumes 0 to 255
+			// normalize from -1 to 1
+			// z = 2*[x - min / (max - min) - 1]
+			// z = 2*(x - 0 / (255 - 0) - 1]
+			// z = 2*(x/255) -1
+			// normalize 0 to 1
+			// x/255
+			double axis_value;
+			if (data[touchid]) {  // Only report touch if there is one
+				axis_value = 2 * data[touchx] / 255.0 - 1;
+				// Attempt to calibrate, assuming trackpads are only good out to about 60%
+				axis_value *= 1.6667;
+				axis_value = std::fmax(-1, std::fmin(axis_value, 1));
+				// invert axis
+				axis_value *= -1;
+				// Fix edge case by guessing appropriate value (necessary because touchid apparently doesn't always work)
+				if (data[touchx] == 0) {
+					axis_value = m_last_axis[idx*NUM_AXIS + 0] < 0 ? -1 : 1;
+				}
+				m_last_axis[idx*NUM_AXIS + 0] = axis_value;
+				osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, axis_value, idx*NUM_AXIS + 0, &m_lastreport_time);
+
+				axis_value = 2 * ((int)data[touchy]) / 255.0 - 1;
+				// Attempt to calibrate, assuming trackpads are only good out to about 60%
+				axis_value *= 1.6667;
+				axis_value = std::fmax(-1, std::fmin(axis_value, 1));
+				// invert axis
+				axis_value *= -1;
+				// Fix edge case by guessing appropriate value (necessary because touchid apparently doesn't always work)
+				if (data[touchy] == 0) {
+					axis_value = m_last_axis[idx*NUM_AXIS + 1] < 0 ? -1 : 1;
+				}
+				m_last_axis[idx*NUM_AXIS + 1] = axis_value;
+				osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, axis_value, idx*NUM_AXIS + 1, &m_lastreport_time);
+			}
+			else { // Otherwise, report a centered value
+				axis_value = 0;
+				osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, axis_value, idx*NUM_AXIS + 0, &m_lastreport_time);
+				osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, axis_value, idx*NUM_AXIS + 1, &m_lastreport_time);
+			}
+			// trigger (emulated analog axis)
+			osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, trigger_pressed, idx*NUM_AXIS + 2, &m_lastreport_time);
+			// battery level
+			axis_value = data[battery] / 255.0;
+			osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, axis_value, idx*NUM_AXIS + 3, &m_lastreport_time);
+
+			// velocity and acceleration data
+			OSVR_LinearVelocityState lin_vel_state;
+			OSVR_LinearAccelerationState lin_accel_state;
+			decodeVelocity(data + velocity, &lin_vel_state);
+			decodeAcceleration(data + accel, &lin_accel_state);
+
+			osvrDeviceTrackerSendLinearVelocityTimestamped(m_dev, m_tracker, &lin_vel_state, 2 + idx, &m_lastreport_time);
+			osvrDeviceTrackerSendLinearAccelerationTimestamped(m_dev, m_tracker, &lin_accel_state, 2 + idx, &m_lastreport_time);
+
+			OSVR_AngularVelocityState ang_vel_state;
+			OSVR_AngularAccelerationState ang_accel_state;
+			decodeAngularVelocity(data + ang_velocity, &ang_vel_state);
+			decodeAngularAcceleration(data + ang_accel, &ang_accel_state);
+
+			osvrDeviceTrackerSendAngularVelocityTimestamped(m_dev, m_tracker, &ang_vel_state, 2 + idx, &m_lastreport_time);
+			osvrDeviceTrackerSendAngularAccelerationTimestamped(m_dev, m_tracker, &ang_accel_state, 2 + idx, &m_lastreport_time);
+
+			// should we be using the "state" information for anything? 
+
+		}
+		void decodeHeadsetMarkerCV1(unsigned char *data) {
+			enum MarkerOffsets {
+				hwversion = 0,	// guessed!
+				fwversion = 1,
+				position = 3,
+				homeposition = 3 + 3 * 2,
+				orientation = 3 + 2 * 3 * 2 + 1,       // why the +1 offset here? (firmware dependent?)
+				velocity = 3 + 2 * 3 * 2 + 1 + 4 * 2,  // Added with 2.0/2.1 firmware
+				accel = 3 + 2 * 3 * 2 + 1 + 7 * 2,
+				ang_velocity = 3 + 2 * 3 * 2 + 1 + 10 * 2,
+				ang_accel = 3 + 2 * 3 * 2 + 1 + 13 * 2,
+				state = 3 + 2 * 3 * 2 + 1 + 16 * 2
+			};
+			if (data[hwversion] != 2 || data[fwversion] != 1) {
+				/* Happens with corrupt packages (mixed with controller data)
+				std::cout << "Nolo: Unknown headset marker"
+				<< " version " << (int)data[0] << " " << (int)data[1]
+				<< std::endl;
+				*/
+				// Unknown version
+				return;
+			}
+
+			OSVR_PositionState home;
+			OSVR_PoseState hmd;
+
+			decodePosition(data + position, &hmd.translation);
+			decodePosition(data + homeposition, &home);
+			decodeOrientation(data + orientation, &hmd.rotation);
+
+			// Send button press if home position changed
+			if (home.data[0] != m_last_home.data[0]) { // An exact comparison on the x value is probably sufficient, if not necessarily proper
+				osvrDeviceButtonSetValueTimestamped(m_dev, m_button, OSVR_BUTTON_PRESSED, 12, &m_lastreport_time);
+				m_last_home.data[0] = home.data[0];
+			}
+			else {
+				osvrDeviceButtonSetValueTimestamped(m_dev, m_button, OSVR_BUTTON_NOT_PRESSED, 12, &m_lastreport_time);
+			}
+
+			// Tracker viewer kept using the home for head.
+			// Something wrong with how they handle the descriptors. 
+			osvrDeviceTrackerSendPositionTimestamped(m_dev, m_tracker, &home, 0,
+				&m_lastreport_time);
+
+			osvrDeviceTrackerSendPoseTimestamped(m_dev, m_tracker, &hmd, 1,
+				&m_lastreport_time);
+
+			// velocity and acceleration data
+			OSVR_LinearVelocityState lin_vel_state;
+			OSVR_LinearAccelerationState lin_accel_state;
+			decodeVelocity(data + velocity, &lin_vel_state);
+			decodeAcceleration(data + accel, &lin_accel_state);
+
+			osvrDeviceTrackerSendLinearVelocityTimestamped(m_dev, m_tracker, &lin_vel_state, 1, &m_lastreport_time);
+			osvrDeviceTrackerSendLinearAccelerationTimestamped(m_dev, m_tracker, &lin_accel_state, 1, &m_lastreport_time);
+
+			OSVR_AngularVelocityState ang_vel_state;
+			OSVR_AngularAccelerationState ang_accel_state;
+			decodeAngularVelocity(data + ang_velocity, &ang_vel_state);
+			decodeAngularAcceleration(data + ang_accel, &ang_accel_state);
+
+			osvrDeviceTrackerSendAngularVelocityTimestamped(m_dev, m_tracker, &ang_vel_state, 1, &m_lastreport_time);
+			osvrDeviceTrackerSendAngularAccelerationTimestamped(m_dev, m_tracker, &ang_accel_state, 1, &m_lastreport_time);
+
+		}
+		void decodeBaseStationCV1(unsigned char *data) {
+			enum MarkerOffsets {
+				hwversion = 0,	// guessed!
+				fwversion = 1,
+				position = 2,        // This is ONLY for the 2.0/2.1 firmware!(looks like things changed)
+				battery = 2 + 3 * 2
+			};
+			if (data[hwversion] != 2 || data[fwversion] != 1)
+				// Unknown version
+				return;
+
+			osvrDeviceAnalogSetValueTimestamped(m_dev, m_analog, data[battery], 2 * NUM_AXIS,
+				&m_lastreport_time);
+		}
+
+		static const int controllerLength = 3 + (3 + 4) * 2 + 2 + 2 + 1;
+		osvr::pluginkit::DeviceToken m_dev;
+		hid_device* m_hid;
+		OSVR_AnalogDeviceInterface m_analog;
+		OSVR_ButtonDeviceInterface m_button;
+		OSVR_TrackerDeviceInterface m_tracker;
+		OSVR_TimeValue m_lastreport_time;
+		OSVR_Vec3 m_last_home;
+		double m_last_axis[NUM_AXIS];
+	};
+
+	class HardwareDetection {
+	public:
+		HardwareDetection() : m_found(false) {}
+		OSVR_ReturnCode operator()(OSVR_PluginRegContext ctx) {
+
+			// TODO: probe for new devices only
+			if (m_found)
+				return OSVR_RETURN_SUCCESS;
+
+			struct hid_device_info *hid_devices, *cur_dev;
+			hid_devices = hid_enumerate(0x0483, 0x5750);
+			if (!hid_devices)
+				return OSVR_RETURN_FAILURE;
+
+			for (cur_dev = hid_devices; cur_dev; cur_dev = cur_dev->next) {
+				if (wcscmp(cur_dev->manufacturer_string, L"LYRobotix") == 0 &&
+					wcscmp(cur_dev->product_string, L"NOLO") == 0) {
+					/// TODO: Distinguish Headset Marker from other parts?
+					/// Create our device object
+					osvr::pluginkit::registerObjectForDeletion
+						(ctx, new NoloDevice(ctx, cur_dev->path));
+					m_found = true;
+				}
+			}
+
+			hid_free_enumeration(hid_devices);
+			return OSVR_RETURN_SUCCESS;
+		}
+
+	private:
+		/// @brief Have we found our device yet? (this limits the plugin to one
+		/// instance)
+		bool m_found;
+	};
+} // namespace
+
+OSVR_PLUGIN(com_osvr_Nolo) {
+	hid_init();
+	osvr::pluginkit::PluginContext context(ctx);
+
+	/// Register a detection callback function object.
+	context.registerHardwareDetectCallback(new HardwareDetection());
+
+	return OSVR_RETURN_SUCCESS;
+}

--- a/com_osvr_Nolo_win.cpp
+++ b/com_osvr_Nolo_win.cpp
@@ -94,8 +94,6 @@ namespace {
 			/// Register update callback
 			m_dev.registerUpdateCallback(this);
 
-			memset(&oldreports[0][0], 0, sizeof oldreports);
-
 			NOLO::registerDisConnectCallBack(disconnectNolo, this);
 			NOLO::registerConnectSuccessCallBack(connectNolo, this);
 			NOLO::registerExpandDataNotifyCallBack(expandDataNotify, this);
@@ -130,6 +128,15 @@ namespace {
 			}
 
 			osvrTimeValueGetNow(&device.m_lastreport_time);
+			static int i = 0;
+			if (i > 10) {
+				std::cout << device.m_lastreport_time.seconds << " " << device.m_lastreport_time.microseconds << "\n";
+				std::cout << data.hmdData.HMDPosition.x << "," << data.hmdData.HMDPosition.y << "," << data.hmdData.HMDPosition.z << "\n";
+				std::cout.flush();
+				i = 0;
+			}
+			++i;
+
 			double translationScale = 1.0f;
 
 			/*
@@ -304,11 +311,7 @@ namespace {
 		}
 
 	private:
-		unsigned char oldreports[2][64];
-		static const int controllerLength = 3 + (3 + 4) * 2 + 2 + 2 + 1;
 		osvr::pluginkit::DeviceToken m_dev;
-		//changeme
-		//hid_device* m_hid;
 		bool m_is_nolo_connected;
 		OSVR_AnalogDeviceInterface m_analog;
 		OSVR_ButtonDeviceInterface m_button;

--- a/com_osvr_Nolo_win.cpp
+++ b/com_osvr_Nolo_win.cpp
@@ -195,7 +195,23 @@ namespace {
 			*/
 			unsigned int leftButtons = data.left_Controller_Data.Buttons;
 			unsigned int rightButtons = data.right_Controller_Data.Buttons;
-			OSVR_ButtonState buttonValues[12];
+			int leftTrigger = 0;
+			int rightTrigger = 0;
+
+			for (unsigned int bid = 0; bid < 5; ++bid) {
+				OSVR_ButtonState leftValue = leftButtons & 1 << bid ? OSVR_BUTTON_PRESSED : OSVR_BUTTON_NOT_PRESSED;
+				OSVR_ButtonState rightValue = rightButtons & 1 << bid ? OSVR_BUTTON_PRESSED : OSVR_BUTTON_NOT_PRESSED;
+				if (bid == 1) {
+					leftTrigger = (int)leftValue;
+					rightTrigger = (int)rightValue;
+				}
+				osvrDeviceButtonSetValueTimestamped(device.m_dev, device.m_button, leftValue, bid, &device.m_lastreport_time);
+				osvrDeviceButtonSetValueTimestamped(device.m_dev, device.m_button, rightValue, bid+6, &device.m_lastreport_time);
+			}
+			osvrDeviceAnalogSetValueTimestamped(device.m_dev, device.m_analog, leftTrigger, 2, &device.m_lastreport_time);
+			osvrDeviceAnalogSetValueTimestamped(device.m_dev, device.m_analog, rightTrigger, 6, &device.m_lastreport_time);
+
+			/*OSVR_ButtonState buttonValues[12];
 
 			for (unsigned int i = 0; i < 5; ++i) {
 				buttonValues[i] = leftButtons & (2 ^ i) == (2 ^ i);
@@ -206,7 +222,7 @@ namespace {
 			}
 			buttonValues[5] = data.left_Controller_Data.ControllerTouched;
 			buttonValues[11] = data.right_Controller_Data.ControllerTouched;
-			osvrDeviceButtonSetValuesTimestamped(device.m_dev, device.m_button, buttonValues, 12, &device.m_lastreport_time);
+			osvrDeviceButtonSetValuesTimestamped(device.m_dev, device.m_button, buttonValues, 12, &device.m_lastreport_time);*/
 
 			/*
 			Report Analog Touchpad
@@ -249,13 +265,13 @@ namespace {
 			double translationScale = 1.0f;
 			osvrVec3SetX(&pos, translationScale * data.x);
 			osvrVec3SetY(&pos, translationScale * data.y);
-			osvrVec3SetZ(&pos, translationScale * data.z);
+			osvrVec3SetZ(&pos, translationScale * -data.z);
 		}
 
 		void SetRotation(OSVR_Quaternion& quat, NOLO::Quaternion& data) {
 			osvrQuatSetW(&quat, data.w);
-			osvrQuatSetX(&quat, data.x);
-			osvrQuatSetY(&quat, data.y);
+			osvrQuatSetX(&quat, -data.x);
+			osvrQuatSetY(&quat, -data.y);
 			osvrQuatSetZ(&quat, data.z);
 		}
 
@@ -263,7 +279,7 @@ namespace {
 			double velocityScale = 1.0f;
 			osvrVec3SetX(&vel.linearVelocity, velocityScale * data.x);
 			osvrVec3SetY(&vel.linearVelocity, velocityScale * data.y);
-			osvrVec3SetZ(&vel.linearVelocity, velocityScale * data.z);
+			osvrVec3SetZ(&vel.linearVelocity, velocityScale * -data.z);
 			vel.linearVelocityValid = true;
 		}
 
@@ -286,7 +302,7 @@ namespace {
 			double accelerationScale = 1.0f;
 			osvrVec3SetX(&acc.linearAcceleration, accelerationScale * data.x);
 			osvrVec3SetY(&acc.linearAcceleration, accelerationScale * data.y);
-			osvrVec3SetZ(&acc.linearAcceleration, accelerationScale * data.z);
+			osvrVec3SetZ(&acc.linearAcceleration, accelerationScale * -data.z);
 			acc.linearAccelerationValid = true;
 		}
 

--- a/com_osvr_Nolo_win.json
+++ b/com_osvr_Nolo_win.json
@@ -9,7 +9,11 @@
       "bounded": true,
       "position": true,
       "orientation": true,
-      "count": 4,
+      "linearVelocity":  true,
+      "angularVelocity":  true,
+      "linearAcceleration":  true,
+      "angularAcceleration":  true, 
+      "count": 8,
       "traits": [{"orientation": false}]
     },
     "analog": {
@@ -18,12 +22,12 @@
         {
           "min": -1,
           "max": 1,
-          "rest": 1
+          "rest": 0
         },
         {
           "min": -1,
           "max": 1,
-          "rest": 1
+          "rest": 0
         },
         {
           "min": 0,
@@ -38,12 +42,12 @@
         {
           "min": -1,
           "max": 1,
-          "rest": 1 
+          "rest": 0 
         },
         {
           "min": -1,
           "max": 1,
-          "rest": 1
+          "rest": 0
         },
         {
           "min": 0,

--- a/com_osvr_Nolo_win.json
+++ b/com_osvr_Nolo_win.json
@@ -67,14 +67,13 @@
       ]
     },
     "button": {
-      "count": 14
+      "count": 12
     }
   },
   "semantic": {
     "hmd": {
       "$target": "tracker/1",
-        "home": "tracker/0",
-        "button": "button/12"
+        "home": "tracker/0"
     },
     "controller": {
       "left": {


### PR DESCRIPTION
I have taken a first pass at adding velocity and acceleration data from the new NOLO firmware. It's fairly straightforward, but there are a number of questions and issues. As a reference for the NOLO controller data I used the latest NOLO Windows HID SDK: 

https://github.com/NOLOVR/NOLO-Windows-SDK/blob/master/NOLOVR/NOLO_USBHID_SDK/include/nolo_api.h

I tested a build of the new plugin by replacing the NOFC v0.2 plugin and firing up SteamVR.  Nothing changed (with the exception of the controller battery indication, see below) and everything still worked, which is what I expected as none of the additional information is used upstream.  So, it doesn't break anything, but that's not saying it's right either. Some comments: 

-> No attempt was made at backwards compatibility with older firmware. Should we do this? It's not clear that FW version is decoded properly as there are explicit checks that I would expect would cause the plugin to fail id the FW value changed.  This needs looking into.  

-> I used the same scale factor for the linear velocity and acceleration as for the position. I think this makes sense? For the angular quantities no such scale factor seems necessary.  I kept separate functions for extracting the data, although they could be combined, as I don't know if they will diverge in the near future. 

-> For the HMD orientation data there is a one byte offset that doesn't make sense to me? I think this is a mistake but didn't change it, or it is something to do with the older firmware.  This will be important to read the velocity and acceleration data as that follows the orientation data.  The HMD orientation could be all messed up but when used with OSVR-fusion the orientation comes from the HDK HMD, so it seems likely it could be messed up and wouldn't be noticed?  This should be confirmed, and fixed. 

-> The latest firmware base station data includes a position vector before the battery field. I updated this, and noticed I no longer get the low battery warning in SteamVR for my controllers.  If this is not coincidence then shouldn't the battery indication come from the controllers themselves and not the base station?  This looks like an issue further upstream. 

If this seems to be on the right track I can evolve it from here. 
